### PR TITLE
Add user-to-user crypto transfer with email verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+CryptocurrencyExchange.EmailService/Properties/launchSettings.json

--- a/CryptocurrencyExchange.EmailService/Consumers/SendVerificationEmailConsumer.cs
+++ b/CryptocurrencyExchange.EmailService/Consumers/SendVerificationEmailConsumer.cs
@@ -1,0 +1,32 @@
+using CryptocurrencyExchange.Core.Events;
+using CryptocurrencyExchange.Core.ValueObject.User;
+using CryptocurrencyExchange.EmailService.Interfaces;
+using MassTransit;
+
+namespace CryptocurrencyExchange.EmailService.Consumers
+{
+    public class SendVerificationEmailConsumer : IConsumer<SendVerificationEmailCommand>
+    {
+        private readonly IEmailSender _emailSender;
+        private readonly ILogger<SendVerificationEmailConsumer> _logger;
+
+        public SendVerificationEmailConsumer(IEmailSender emailSender, ILogger<SendVerificationEmailConsumer> logger)
+        {
+            _emailSender = emailSender;
+            _logger = logger;
+        }
+
+        public async Task Consume(ConsumeContext<SendVerificationEmailCommand> context)
+        {
+            var command = context.Message;
+            var email = new Email(command.Email);
+
+            _logger.LogInformation("Processing verification email for {Email}", email.Value);
+
+            var subject = "Your Verification Code";
+            var body = $"<p>Your verification code is: <strong>{command.VerificationCode}</strong></p>";
+
+            await _emailSender.SendAsync(email.Value, subject, body, context.CancellationToken);
+        }
+    }
+}

--- a/CryptocurrencyExchange.EmailService/CryptocurrencyExchange.EmailService.csproj
+++ b/CryptocurrencyExchange.EmailService/CryptocurrencyExchange.EmailService.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MailKit" Version="4.3.0" />
+    <PackageReference Include="MassTransit" Version="8.2.5" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.2.5" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="9.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CryptocurrencyExchange\CryptocurrencyExchange.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CryptocurrencyExchange.EmailService/Infrastructure/MailKitEmailSender.cs
+++ b/CryptocurrencyExchange.EmailService/Infrastructure/MailKitEmailSender.cs
@@ -1,0 +1,48 @@
+using CryptocurrencyExchange.EmailService.Interfaces;
+using CryptocurrencyExchange.EmailService.Options;
+using CryptocurrencyExchange.Exceptions;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Options;
+using MimeKit;
+
+namespace CryptocurrencyExchange.EmailService.Infrastructure
+{
+    public class MailKitEmailSender : IEmailSender
+    {
+        private readonly SmtpOptions _options;
+        private readonly ILogger<MailKitEmailSender> _logger;
+
+        public MailKitEmailSender(IOptions<SmtpOptions> options, ILogger<MailKitEmailSender> logger)
+        {
+            _options = options.Value;
+            _logger = logger;
+        }
+
+        public async Task SendAsync(string to, string subject, string body, CancellationToken ct = default)
+        {
+            var message = new MimeMessage();
+            message.From.Add(new MailboxAddress(_options.FromName, _options.FromAddress));
+            message.To.Add(MailboxAddress.Parse(to));
+            message.Subject = subject;
+            message.Body = new TextPart("html") { Text = body };
+
+            try
+            {
+                using var client = new SmtpClient();
+                var socketOptions = _options.UseSsl ? SecureSocketOptions.StartTls : SecureSocketOptions.None;
+                await client.ConnectAsync(_options.Host, _options.Port, socketOptions, ct);
+                await client.AuthenticateAsync(_options.Username, _options.Password, ct);
+                await client.SendAsync(message, ct);
+                await client.DisconnectAsync(true, ct);
+
+                _logger.LogInformation("Email sent to {Recipient}", to);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send email to {Recipient}", to);
+                throw new EmailSendingFailedException(to, ex);
+            }
+        }
+    }
+}

--- a/CryptocurrencyExchange.EmailService/Interfaces/IEmailSender.cs
+++ b/CryptocurrencyExchange.EmailService/Interfaces/IEmailSender.cs
@@ -1,0 +1,7 @@
+namespace CryptocurrencyExchange.EmailService.Interfaces
+{
+    public interface IEmailSender
+    {
+        Task SendAsync(string to, string subject, string body, CancellationToken ct = default);
+    }
+}

--- a/CryptocurrencyExchange.EmailService/Options/SmtpOptions.cs
+++ b/CryptocurrencyExchange.EmailService/Options/SmtpOptions.cs
@@ -1,0 +1,13 @@
+namespace CryptocurrencyExchange.EmailService.Options
+{
+    public class SmtpOptions
+    {
+        public string Host { get; init; } = null!;
+        public int Port { get; init; } = 587;
+        public string Username { get; init; } = null!;
+        public string Password { get; set; } = null!;
+        public string FromAddress { get; init; } = null!;
+        public string FromName { get; init; } = "CryptocurrencyExchange";
+        public bool UseSsl { get; init; } = true;
+    }
+}

--- a/CryptocurrencyExchange.EmailService/Program.cs
+++ b/CryptocurrencyExchange.EmailService/Program.cs
@@ -1,0 +1,64 @@
+using CryptocurrencyExchange.EmailService.Interfaces;
+using CryptocurrencyExchange.EmailService.Consumers;
+using CryptocurrencyExchange.EmailService.Infrastructure;
+using CryptocurrencyExchange.EmailService.Options;
+using CryptocurrencyExchange.Options;
+using MassTransit;
+using Microsoft.Extensions.Options;
+using Serilog;
+
+var host = Host.CreateDefaultBuilder(args)
+    .UseSerilog((context, _, config) =>
+    {
+        config.ReadFrom.Configuration(context.Configuration)
+              .Enrich.FromLogContext();
+    })
+    .ConfigureServices((context, services) =>
+    {
+        var configuration = context.Configuration;
+
+        services
+            .AddOptions<SmtpOptions>()
+            .Bind(configuration.GetSection("Smtp"))
+            .Configure(o => o.Password = Environment.GetEnvironmentVariable("SMTP_PASSWORD") ?? o.Password)
+            .Validate(o => !string.IsNullOrWhiteSpace(o.Host), "Smtp:Host is required")
+            .Validate(o => o.Port > 0, "Smtp:Port must be positive")
+            .Validate(o => !string.IsNullOrWhiteSpace(o.Username), "Smtp:Username is required")
+            .Validate(o => !string.IsNullOrWhiteSpace(o.Password), "Smtp:Password is required")
+            .Validate(o => !string.IsNullOrWhiteSpace(o.FromAddress), "Smtp:FromAddress is required")
+            .ValidateOnStart();
+
+        services
+            .AddOptions<RabbitMqOptions>()
+            .Bind(configuration.GetSection("RabbitMq"))
+            .Validate(o => !string.IsNullOrWhiteSpace(o.Host))
+            .Validate(o => !string.IsNullOrWhiteSpace(o.Username))
+            .Validate(o => !string.IsNullOrWhiteSpace(o.Password))
+            .ValidateOnStart();
+
+        services.AddSingleton<IEmailSender, MailKitEmailSender>();
+
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<SendVerificationEmailConsumer>();
+
+            x.UsingRabbitMq((ctx, cfg) =>
+            {
+                var options = ctx.GetRequiredService<IOptions<RabbitMqOptions>>().Value;
+
+                cfg.Host(options.Host, options.VirtualHost, h =>
+                {
+                    h.Username(options.Username);
+                    h.Password(options.Password);
+                });
+
+                cfg.ReceiveEndpoint("email.send-verification", e =>
+                {
+                    e.ConfigureConsumer<SendVerificationEmailConsumer>(ctx);
+                });
+            });
+        });
+    })
+    .Build();
+
+await host.RunAsync();

--- a/CryptocurrencyExchange.EmailService/appsettings.json
+++ b/CryptocurrencyExchange.EmailService/appsettings.json
@@ -16,7 +16,7 @@
     "Username": "yurabalint0103@gmail.com",
     "Password": "",
     "FromAddress": "yurabalint0103@gmail.com",
-    "FromName": "",
+    "FromName": "CryptoExchange",
     "UseSsl": true
   }
 }

--- a/CryptocurrencyExchange.EmailService/appsettings.json
+++ b/CryptocurrencyExchange.EmailService/appsettings.json
@@ -1,0 +1,22 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information"
+    }
+  },
+  "RabbitMq": {
+    "Host": "localhost",
+    "VirtualHost": "/",
+    "Username": "guest",
+    "Password": "guest"
+  },
+  "Smtp": {
+    "Host": "smtp.gmail.com",
+    "Port": 587,
+    "Username": "yurabalint0103@gmail.com",
+    "Password": "",
+    "FromAddress": "yurabalint0103@gmail.com",
+    "FromName": "",
+    "UseSsl": true
+  }
+}

--- a/CryptocurrencyExchange.Tests/CryptocurrencyExchange.Tests.csproj
+++ b/CryptocurrencyExchange.Tests/CryptocurrencyExchange.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CryptocurrencyExchange\CryptocurrencyExchange.csproj" />
+    <ProjectReference Include="..\CryptocurrencyExchange.EmailService\CryptocurrencyExchange.EmailService.csproj" />
   </ItemGroup>
 
 </Project>

--- a/CryptocurrencyExchange.Tests/Domain/TransferTests.cs
+++ b/CryptocurrencyExchange.Tests/Domain/TransferTests.cs
@@ -1,0 +1,64 @@
+using CryptocurrencyExchange.Core.Models;
+using CryptocurrencyExchange.Core.ValueObject;
+using CryptocurrencyExchange.Exceptions;
+using NUnit.Framework;
+
+namespace CryptocurrencyExchange.Tests.Domain
+{
+    [TestFixture]
+    internal class TransferTests
+    {
+        private const int SenderId = 1;
+        private const int ReceiverId = 2;
+        private const string Code = "123456";
+
+        [Test]
+        public void Execute_CorrectCode_ShouldDeductSenderAndCreditReceiver()
+        {
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 1m, Code);
+            var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 5m);
+            var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
+
+            transfer.Execute(senderItem, receiverItem, new VerificationCode(Code));
+
+            Assert.That(senderItem.Amount.Value, Is.EqualTo(4m));
+            Assert.That(receiverItem.Amount.Value, Is.EqualTo(1m));
+            Assert.That(transfer.Status, Is.EqualTo(TransferStatus.Completed));
+        }
+
+        [Test]
+        public void Execute_WrongCode_ShouldThrowInvalidVerificationCodeException()
+        {
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 1m, Code);
+            var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 5m);
+            var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
+
+            Assert.Throws<InvalidVerificationCodeException>(() =>
+                transfer.Execute(senderItem, receiverItem, new VerificationCode("999999")));
+        }
+
+        [Test]
+        public void Execute_AlreadyCompleted_ShouldThrowInvalidOperationException()
+        {
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 1m, Code);
+            var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 5m);
+            var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
+
+            transfer.Execute(senderItem, receiverItem, new VerificationCode(Code));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                transfer.Execute(senderItem, receiverItem, new VerificationCode(Code)));
+        }
+
+        [Test]
+        public void Execute_InsufficientFunds_ShouldThrowInsufficientFundsException()
+        {
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 10m, Code);
+            var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 5m);
+            var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
+
+            Assert.Throws<InsufficientFundsException>(() =>
+                transfer.Execute(senderItem, receiverItem, new VerificationCode(Code)));
+        }
+    }
+}

--- a/CryptocurrencyExchange.Tests/Infrastructure/SendVerificationEmailConsumerTests.cs
+++ b/CryptocurrencyExchange.Tests/Infrastructure/SendVerificationEmailConsumerTests.cs
@@ -1,0 +1,73 @@
+using CryptocurrencyExchange.Core.Events;
+using CryptocurrencyExchange.EmailService.Interfaces;
+using CryptocurrencyExchange.EmailService.Consumers;
+using CryptocurrencyExchange.Exceptions;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace CryptocurrencyExchange.Tests.Infrastructure
+{
+    [TestFixture]
+    public class SendVerificationEmailConsumerTests
+    {
+        private Mock<IEmailSender> _emailSender;
+        private SendVerificationEmailConsumer _consumer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _emailSender = new Mock<IEmailSender>();
+            _consumer = new SendVerificationEmailConsumer(
+                _emailSender.Object,
+                Mock.Of<ILogger<SendVerificationEmailConsumer>>());
+        }
+
+        [Test]
+        public async Task Consume_ValidEmail_SendsVerificationEmail()
+        {
+            var command = new SendVerificationEmailCommand("test@example.com", "123456");
+            var context = Mock.Of<ConsumeContext<SendVerificationEmailCommand>>(
+                c => c.Message == command && c.CancellationToken == CancellationToken.None);
+
+            await _consumer.Consume(context);
+
+            _emailSender.Verify(
+                x => x.SendAsync(
+                    "test@example.com",
+                    It.IsAny<string>(),
+                    It.Is<string>(b => b.Contains("123456")),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
+        public void Consume_InvalidEmail_ThrowsInvalidEmailException()
+        {
+            var command = new SendVerificationEmailCommand("not-an-email", "123456");
+            var context = Mock.Of<ConsumeContext<SendVerificationEmailCommand>>(
+                c => c.Message == command && c.CancellationToken == CancellationToken.None);
+
+            Assert.ThrowsAsync<InvalidEmailException>(() => _consumer.Consume(context));
+        }
+
+        [Test]
+        public void Consume_WhenSendFails_ThrowsEmailSendingFailedException()
+        {
+            var command = new SendVerificationEmailCommand("test@example.com", "123456");
+            var context = Mock.Of<ConsumeContext<SendVerificationEmailCommand>>(
+                c => c.Message == command && c.CancellationToken == CancellationToken.None);
+
+            _emailSender
+                .Setup(x => x.SendAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new EmailSendingFailedException("test@example.com"));
+
+            Assert.ThrowsAsync<EmailSendingFailedException>(() => _consumer.Consume(context));
+        }
+    }
+}

--- a/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
+++ b/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
@@ -1,0 +1,198 @@
+using CryptocurrencyExchange.Application.Transfers;
+using CryptocurrencyExchange.Core.Events;
+using CryptocurrencyExchange.Core.Interfaces;
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using CryptocurrencyExchange.Core.ValueObject;
+using CryptocurrencyExchange.Core.ValueObject.User;
+using CryptocurrencyExchange.Exceptions;
+using MassTransit;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+
+namespace CryptocurrencyExchange.Tests.ServicesTests
+{
+    [TestFixture]
+    public class TransferServiceTests
+    {
+        private Mock<ITransferRepository> _transferRepo;
+        private Mock<IWalletItemRepository> _walletRepo;
+        private Mock<IUserRepository> _userRepo;
+        private Mock<IUnitOfWork> _uow;
+        private Mock<IPublishEndpoint> _publishEndpoint;
+
+        private TransferService _service;
+
+        private const int SenderId = 1;
+        private const int ReceiverId = 2;
+        private static readonly Email SenderEmail = new("sender@test.com");
+        private static readonly Email ReceiverEmail = new("receiver@test.com");
+
+        [SetUp]
+        public void SetUp()
+        {
+            _transferRepo = new Mock<ITransferRepository>();
+            _walletRepo = new Mock<IWalletItemRepository>();
+            _userRepo = new Mock<IUserRepository>();
+            _uow = new Mock<IUnitOfWork>();
+            _publishEndpoint = new Mock<IPublishEndpoint>();
+
+            _uow.Setup(x => x.ExecuteInTransactionAsync(It.IsAny<Func<Task>>()))
+                .Returns<Func<Task>>(f => f());
+
+            _service = new TransferService(
+                _transferRepo.Object,
+                _walletRepo.Object,
+                _userRepo.Object,
+                _uow.Object,
+                _publishEndpoint.Object,
+                NullLogger<TransferService>.Instance
+            );
+        }
+
+        [Test]
+        public async Task InitiateAsync_ValidRequest_ShouldCreateTransferAndPublishEmail()
+        {
+            var receiver = new User(ReceiverEmail, new byte[] { 1 }, new byte[] { 2 });
+            var senderItem = new WalletItem(SenderId, CoinSymbol.Btc);
+            senderItem.AddAmount(10m);
+            SetUserProperty(senderItem, new User(SenderEmail, new byte[] { 3 }, new byte[] { 4 }));
+
+            _userRepo.Setup(x => x.GetByEmailAsync(ReceiverEmail)).ReturnsAsync(receiver);
+            _walletRepo.Setup(x => x.GetWithUserAsync(SenderId, CoinSymbol.Btc)).ReturnsAsync(senderItem);
+
+            var dto = new InitiateTransferDto(ReceiverEmail, "btc", 5m);
+            var transferId = await _service.InitiateAsync(SenderId, dto);
+
+            _transferRepo.Verify(x => x.AddAsync(It.IsAny<Transfer>()), Times.Once);
+            _publishEndpoint.Verify(
+                x => x.Publish(It.IsAny<SendVerificationEmailCommand>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Test]
+        public void InitiateAsync_ReceiverNotFound_ShouldThrowUserNotFoundException()
+        {
+            _userRepo.Setup(x => x.GetByEmailAsync(It.IsAny<string>())).ReturnsAsync((User)null);
+
+            var dto = new InitiateTransferDto("unknown@test.com", "btc", 5m);
+
+            Assert.ThrowsAsync<UserNotFoundException>(async () =>
+                await _service.InitiateAsync(SenderId, dto));
+        }
+
+        [Test]
+        public void InitiateAsync_SelfTransfer_ShouldThrowSelfTransferException()
+        {
+            var sender = new User(SenderEmail, new byte[] { 1 }, new byte[] { 2 });
+            _userRepo.Setup(x => x.GetByEmailAsync(SenderEmail)).ReturnsAsync(sender);
+
+            var dto = new InitiateTransferDto(SenderEmail, "btc", 5m);
+
+            Assert.ThrowsAsync<SelfTransferException>(async () =>
+                await _service.InitiateAsync(sender.Id, dto));
+        }
+
+        [Test]
+        public void InitiateAsync_InsufficientFunds_ShouldThrowInsufficientFundsException()
+        {
+            var receiver = new User(ReceiverEmail, new byte[] { 1 }, new byte[] { 2 });
+            var senderItem = new WalletItem(SenderId, CoinSymbol.Btc);
+            senderItem.AddAmount(1m);
+            SetUserProperty(senderItem, new User(SenderEmail, new byte[] { 3 }, new byte[] { 4 }));
+
+            _userRepo.Setup(x => x.GetByEmailAsync(ReceiverEmail)).ReturnsAsync(receiver);
+            _walletRepo.Setup(x => x.GetWithUserAsync(SenderId, CoinSymbol.Btc)).ReturnsAsync(senderItem);
+
+            var dto = new InitiateTransferDto(ReceiverEmail, "btc", 10m);
+
+            Assert.ThrowsAsync<InsufficientFundsException>(async () =>
+                await _service.InitiateAsync(SenderId, dto));
+        }
+
+        [Test]
+        public void InitiateAsync_SenderHasNoWalletItem_ShouldThrowWalletItemNotFoundException()
+        {
+            var receiver = new User(ReceiverEmail, new byte[] { 1 }, new byte[] { 2 });
+            _userRepo.Setup(x => x.GetByEmailAsync(ReceiverEmail)).ReturnsAsync(receiver);
+            _walletRepo.Setup(x => x.GetWithUserAsync(SenderId, CoinSymbol.Btc)).ReturnsAsync((WalletItem)null);
+
+            var dto = new InitiateTransferDto(ReceiverEmail, "btc", 5m);
+
+            Assert.ThrowsAsync<WalletItemNotFoundException>(async () =>
+                await _service.InitiateAsync(SenderId, dto));
+        }
+
+        [Test]
+        public async Task ConfirmAsync_ValidCode_ShouldCompleteTransfer()
+        {
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, "123456");
+            var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 10m);
+            var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
+
+            _transferRepo.Setup(x => x.GetPendingByIdAndSenderAsync(0, SenderId)).ReturnsAsync(transfer);
+            _walletRepo.Setup(x => x.GetForTransferAsync(SenderId, ReceiverId, CoinSymbol.Btc))
+                .ReturnsAsync((senderItem, receiverItem));
+
+            var dto = new ConfirmTransferDto(0, "123456");
+            await _service.ConfirmAsync(SenderId, dto);
+
+            Assert.That(senderItem.Amount.Value, Is.EqualTo(5m));
+            Assert.That(receiverItem.Amount.Value, Is.EqualTo(5m));
+            Assert.That(transfer.Status, Is.EqualTo(TransferStatus.Completed));
+        }
+
+        [Test]
+        public void ConfirmAsync_TransferNotFound_ShouldThrowTransferNotFoundException()
+        {
+            _transferRepo.Setup(x => x.GetPendingByIdAndSenderAsync(99, SenderId))
+                .ReturnsAsync((Transfer)null);
+
+            var dto = new ConfirmTransferDto(99, "123456");
+
+            Assert.ThrowsAsync<TransferNotFoundException>(async () =>
+                await _service.ConfirmAsync(SenderId, dto));
+        }
+
+        [Test]
+        public void ConfirmAsync_WrongCode_ShouldThrowInvalidVerificationCodeException()
+        {
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, "123456");
+            var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 10m);
+            var receiverItem = WalletItemMother.CreateItem(ReceiverId, "btc", 0m);
+
+            _transferRepo.Setup(x => x.GetPendingByIdAndSenderAsync(0, SenderId)).ReturnsAsync(transfer);
+            _walletRepo.Setup(x => x.GetForTransferAsync(SenderId, ReceiverId, CoinSymbol.Btc))
+                .ReturnsAsync((senderItem, receiverItem));
+
+            var dto = new ConfirmTransferDto(0, "999999");
+
+            Assert.ThrowsAsync<InvalidVerificationCodeException>(async () =>
+                await _service.ConfirmAsync(SenderId, dto));
+        }
+
+        [Test]
+        public async Task ConfirmAsync_ReceiverHasNoWalletItem_ShouldCreateAndTransfer()
+        {
+            var transfer = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, "123456");
+            var senderItem = WalletItemMother.CreateItem(SenderId, "btc", 10m);
+
+            _transferRepo.Setup(x => x.GetPendingByIdAndSenderAsync(0, SenderId)).ReturnsAsync(transfer);
+            _walletRepo.Setup(x => x.GetForTransferAsync(SenderId, ReceiverId, CoinSymbol.Btc))
+                .ReturnsAsync((senderItem, null));
+
+            var dto = new ConfirmTransferDto(0, "123456");
+            await _service.ConfirmAsync(SenderId, dto);
+
+            _walletRepo.Verify(x => x.AddAsync(It.IsAny<WalletItem>()), Times.Once);
+            Assert.That(senderItem.Amount.Value, Is.EqualTo(5m));
+        }
+
+        private static void SetUserProperty(WalletItem item, User user)
+        {
+            var prop = typeof(WalletItem).GetProperty("User");
+            prop!.SetValue(item, user);
+        }
+    }
+}

--- a/CryptocurrencyExchange.Tests/WalletItemMother.cs
+++ b/CryptocurrencyExchange.Tests/WalletItemMother.cs
@@ -28,5 +28,13 @@ namespace CryptocurrencyExchange.Tests
 
             return item;
         }
+
+        public static WalletItem CreateItem(int userId, string symbol, decimal amount)
+        {
+            var item = new WalletItem(userId, new CoinSymbol(symbol));
+            item.AddAmount(amount);
+
+            return item;
+        }
     }
 }

--- a/CryptocurrencyExchange.sln
+++ b/CryptocurrencyExchange.sln
@@ -7,20 +7,54 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CryptocurrencyExchange", "C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CryptocurrencyExchange.Tests", "CryptocurrencyExchange.Tests\CryptocurrencyExchange.Tests.csproj", "{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CryptocurrencyExchange.EmailService", "CryptocurrencyExchange.EmailService\CryptocurrencyExchange.EmailService.csproj", "{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Debug|x64.Build.0 = Debug|Any CPU
+		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Debug|x86.Build.0 = Debug|Any CPU
 		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Release|x64.ActiveCfg = Release|Any CPU
+		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Release|x64.Build.0 = Release|Any CPU
+		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Release|x86.ActiveCfg = Release|Any CPU
+		{C7A71318-D270-448C-8AF7-4FDE8625389D}.Release|x86.Build.0 = Release|Any CPU
 		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Debug|x64.Build.0 = Debug|Any CPU
+		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Debug|x86.Build.0 = Debug|Any CPU
 		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Release|x64.ActiveCfg = Release|Any CPU
+		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Release|x64.Build.0 = Release|Any CPU
+		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Release|x86.ActiveCfg = Release|Any CPU
+		{5238818F-0EA3-48D5-8351-9CCB51E5F0B2}.Release|x86.Build.0 = Release|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Debug|x64.Build.0 = Debug|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Debug|x86.Build.0 = Debug|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Release|x64.ActiveCfg = Release|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Release|x64.Build.0 = Release|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Release|x86.ActiveCfg = Release|Any CPU
+		{12AE1B37-7A08-4300-86D5-6A15C2CC6A6B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CryptocurrencyExchange/Application/Transfer/ConfirmTransferDto.cs
+++ b/CryptocurrencyExchange/Application/Transfer/ConfirmTransferDto.cs
@@ -1,0 +1,4 @@
+namespace CryptocurrencyExchange.Application.Transfers
+{
+    public record ConfirmTransferDto(int TransferId, string VerificationCode);
+}

--- a/CryptocurrencyExchange/Application/Transfer/InitiateTransferDto.cs
+++ b/CryptocurrencyExchange/Application/Transfer/InitiateTransferDto.cs
@@ -1,0 +1,4 @@
+namespace CryptocurrencyExchange.Application.Transfers
+{
+    public record InitiateTransferDto(string ReceiverEmail, string CoinSymbol, decimal Amount);
+}

--- a/CryptocurrencyExchange/Application/Transfer/TransferService.cs
+++ b/CryptocurrencyExchange/Application/Transfer/TransferService.cs
@@ -1,0 +1,98 @@
+using CryptocurrencyExchange.Core.Events;
+using CryptocurrencyExchange.Core.Interfaces;
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Interfaces.Services;
+using CryptocurrencyExchange.Core.Models;
+using CryptocurrencyExchange.Core.ValueObject;
+using CryptocurrencyExchange.Exceptions;
+using MassTransit;
+
+namespace CryptocurrencyExchange.Application.Transfers
+{
+    public class TransferService : ITransferService
+    {
+        private readonly ITransferRepository _transferRepository;
+        private readonly IWalletItemRepository _walletItemRepository;
+        private readonly IUserRepository _userRepository;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IPublishEndpoint _publishEndpoint;
+        private readonly ILogger<TransferService> _logger;
+
+        public TransferService(
+            ITransferRepository transferRepository,
+            IWalletItemRepository walletItemRepository,
+            IUserRepository userRepository,
+            IUnitOfWork unitOfWork,
+            IPublishEndpoint publishEndpoint,
+            ILogger<TransferService> logger)
+        {
+            _transferRepository = transferRepository;
+            _walletItemRepository = walletItemRepository;
+            _userRepository = userRepository;
+            _unitOfWork = unitOfWork;
+            _publishEndpoint = publishEndpoint;
+            _logger = logger;
+        }
+
+        public async Task<int> InitiateAsync(int senderId, InitiateTransferDto dto)
+        {
+            var receiver = await _userRepository.GetByEmailAsync(dto.ReceiverEmail)
+                ?? throw new UserNotFoundException();
+
+            if (receiver.Id == senderId)
+                throw new SelfTransferException();
+
+            var symbol = new CoinSymbol(dto.CoinSymbol);
+
+            var senderItem = await _walletItemRepository.GetWithUserAsync(senderId, symbol)
+                ?? throw new WalletItemNotFoundException();
+
+            if (senderItem.Amount.Value < dto.Amount)
+                throw new InsufficientFundsException();
+
+            var code = GenerateCode();
+            Transfer transfer = null;
+
+            await _unitOfWork.ExecuteInTransactionAsync(async () =>
+            {
+                transfer = Transfer.Create(senderId, receiver.Id, symbol, dto.Amount, code);
+                await _transferRepository.AddAsync(transfer);
+            });
+
+            await _publishEndpoint.Publish(new SendVerificationEmailCommand(senderItem.User.Email, code));
+
+            _logger.LogInformation("Transfer {TransferId} initiated by user {SenderId}", transfer.Id, senderId);
+
+            return transfer.Id;
+        }
+
+        public async Task ConfirmAsync(int senderId, ConfirmTransferDto dto)
+        {
+            var codeVo = new VerificationCode(dto.VerificationCode);
+
+            var transfer = await _transferRepository.GetPendingByIdAndSenderAsync(dto.TransferId, senderId)
+                ?? throw new TransferNotFoundException();
+
+            await _unitOfWork.ExecuteInTransactionAsync(async () =>
+            {
+                var (senderItem, receiverItem) = await _walletItemRepository
+                    .GetForTransferAsync(senderId, transfer.ReceiverId, transfer.Symbol);
+
+                if (senderItem is null)
+                    throw new WalletItemNotFoundException();
+
+                if (receiverItem is null)
+                {
+                    receiverItem = new WalletItem(transfer.ReceiverId, transfer.Symbol);
+                    await _walletItemRepository.AddAsync(receiverItem);
+                }
+
+                transfer.Execute(senderItem, receiverItem, codeVo);
+            });
+
+            _logger.LogInformation("Transfer {TransferId} completed by user {SenderId}", dto.TransferId, senderId);
+        }
+
+        private static string GenerateCode() => Random.Shared.Next(100_000, 1_000_000).ToString();
+    }
+}

--- a/CryptocurrencyExchange/Core/Entities/Transfer.cs
+++ b/CryptocurrencyExchange/Core/Entities/Transfer.cs
@@ -1,0 +1,48 @@
+using CryptocurrencyExchange.Core.ValueObject;
+using CryptocurrencyExchange.Exceptions;
+
+namespace CryptocurrencyExchange.Core.Models
+{
+    public enum TransferStatus { Pending, Completed }
+
+    public class Transfer
+    {
+        public int Id { get; private set; }
+        public int SenderId { get; private set; }
+        public int ReceiverId { get; private set; }
+        public CoinSymbol Symbol { get; private set; }
+        public decimal Amount { get; private set; }
+        public VerificationCode Code { get; private set; }
+        public TransferStatus Status { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+
+        private Transfer() { }
+
+        public static Transfer Create(int senderId, int receiverId, CoinSymbol symbol, decimal amount, string verificationCode)
+        {
+            return new Transfer
+            {
+                SenderId = senderId,
+                ReceiverId = receiverId,
+                Symbol = symbol,
+                Amount = amount,
+                Code = new VerificationCode(verificationCode),
+                Status = TransferStatus.Pending,
+                CreatedAt = DateTime.UtcNow
+            };
+        }
+
+        public void Execute(WalletItem senderItem, WalletItem receiverItem, VerificationCode submittedCode)
+        {
+            if (Status != TransferStatus.Pending)
+                throw new InvalidOperationException("Transfer is not in a pending state.");
+
+            if (Code != submittedCode)
+                throw new InvalidVerificationCodeException();
+
+            senderItem.RemoveAmount(Amount);
+            receiverItem.AddAmount(Amount);
+            Status = TransferStatus.Completed;
+        }
+    }
+}

--- a/CryptocurrencyExchange/Core/Events/SendVerificationEmailCommand.cs
+++ b/CryptocurrencyExchange/Core/Events/SendVerificationEmailCommand.cs
@@ -1,0 +1,4 @@
+namespace CryptocurrencyExchange.Core.Events
+{
+    public record SendVerificationEmailCommand(string Email, string VerificationCode);
+}

--- a/CryptocurrencyExchange/Core/Exceptions/EmailSendingFailedException.cs
+++ b/CryptocurrencyExchange/Core/Exceptions/EmailSendingFailedException.cs
@@ -1,0 +1,15 @@
+namespace CryptocurrencyExchange.Exceptions
+{
+    public class EmailSendingFailedException : Exception
+    {
+        public EmailSendingFailedException(string email)
+            : base($"Failed to send email to '{email}'.")
+        {
+        }
+
+        public EmailSendingFailedException(string email, Exception innerException)
+            : base($"Failed to send email to '{email}'.", innerException)
+        {
+        }
+    }
+}

--- a/CryptocurrencyExchange/Core/Exceptions/InvalidVerificationCodeException.cs
+++ b/CryptocurrencyExchange/Core/Exceptions/InvalidVerificationCodeException.cs
@@ -1,0 +1,10 @@
+namespace CryptocurrencyExchange.Exceptions
+{
+    public class InvalidVerificationCodeException : Exception
+    {
+        public InvalidVerificationCodeException()
+            : base("The verification code is invalid.")
+        {
+        }
+    }
+}

--- a/CryptocurrencyExchange/Core/Exceptions/SelfTransferException.cs
+++ b/CryptocurrencyExchange/Core/Exceptions/SelfTransferException.cs
@@ -1,0 +1,10 @@
+namespace CryptocurrencyExchange.Exceptions
+{
+    public class SelfTransferException : Exception
+    {
+        public SelfTransferException()
+            : base("Cannot transfer funds to yourself.")
+        {
+        }
+    }
+}

--- a/CryptocurrencyExchange/Core/Exceptions/TransferNotFoundException.cs
+++ b/CryptocurrencyExchange/Core/Exceptions/TransferNotFoundException.cs
@@ -1,0 +1,10 @@
+namespace CryptocurrencyExchange.Exceptions
+{
+    public class TransferNotFoundException : Exception
+    {
+        public TransferNotFoundException()
+            : base("Transfer not found.")
+        {
+        }
+    }
+}

--- a/CryptocurrencyExchange/Core/Interfaces/Repositories/ITransferRepository.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Repositories/ITransferRepository.cs
@@ -1,0 +1,10 @@
+using CryptocurrencyExchange.Core.Models;
+
+namespace CryptocurrencyExchange.Core.Interfaces.Repositories
+{
+    public interface ITransferRepository
+    {
+        Task AddAsync(Transfer transfer);
+        Task<Transfer?> GetPendingByIdAndSenderAsync(int transferId, int senderId);
+    }
+}

--- a/CryptocurrencyExchange/Core/Interfaces/Repositories/IWalletItemRepository.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Repositories/IWalletItemRepository.cs
@@ -8,7 +8,9 @@ namespace CryptocurrencyExchange.Core.Interfaces.Repositories
         Task<List<WalletItem>> GetNonEmptyByUserAsync(int userId);
 
         Task<WalletItem?> GetAsync(int userId, CoinSymbol symbol);
+        Task<WalletItem?> GetWithUserAsync(int userId, CoinSymbol symbol);
         Task AddAsync(WalletItem item);
         Task<TradeWalletItems> GetCoinsDataForTradeAsync(int userId, CoinSymbol coinSymbol);
+        Task<(WalletItem? Sender, WalletItem? Receiver)> GetForTransferAsync(int senderId, int receiverId, CoinSymbol symbol);
     }
 }

--- a/CryptocurrencyExchange/Core/Interfaces/Services/ITransferService.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Services/ITransferService.cs
@@ -1,0 +1,10 @@
+using CryptocurrencyExchange.Application.Transfers;
+
+namespace CryptocurrencyExchange.Core.Interfaces.Services
+{
+    public interface ITransferService
+    {
+        Task<int> InitiateAsync(int senderId, InitiateTransferDto dto);
+        Task ConfirmAsync(int senderId, ConfirmTransferDto dto);
+    }
+}

--- a/CryptocurrencyExchange/Core/ValueObject/VerificationCode.cs
+++ b/CryptocurrencyExchange/Core/ValueObject/VerificationCode.cs
@@ -1,0 +1,17 @@
+namespace CryptocurrencyExchange.Core.ValueObject
+{
+    public readonly record struct VerificationCode
+    {
+        public string Value { get; }
+
+        public VerificationCode(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || value.Length != 6 || !value.All(char.IsDigit))
+                throw new ArgumentException("Verification code must be exactly 6 digits.");
+
+            Value = value;
+        }
+
+        public override string ToString() => Value;
+    }
+}

--- a/CryptocurrencyExchange/Extensions/InfrastructureCollectionExtensions.cs
+++ b/CryptocurrencyExchange/Extensions/InfrastructureCollectionExtensions.cs
@@ -40,6 +40,7 @@ namespace CryptocurrencyExchange.Extensions
             services.AddScoped<IFutureRepository, EfFutureRepository>();
             services.AddScoped<ICryptoNewsRepository, NewPersistence>();
             services.AddScoped<IUserRepository, EfUserRepository>();
+            services.AddScoped<ITransferRepository, EfTransferRepository>();
 
             return services;
         }

--- a/CryptocurrencyExchange/Extensions/ServiceCollectionExtensions.cs
+++ b/CryptocurrencyExchange/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using CryptocurrencyExchange.Application.Market;
 using CryptocurrencyExchange.Application.Notifications;
 using CryptocurrencyExchange.Application.StakingServices;
 using CryptocurrencyExchange.Application.Users;
+using CryptocurrencyExchange.Application.Transfers;
 using CryptocurrencyExchange.Application.Wallets;
 
 namespace CryptocurrencyExchange.Extensions
@@ -22,6 +23,7 @@ namespace CryptocurrencyExchange.Extensions
             services.AddScoped<IAuthService, AuthService>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<INotificationService, NotificationService>();
+            services.AddScoped<ITransferService, TransferService>();
 
             services.AddScoped<IStakingDomainService, StakingDomainService>();
             services.AddScoped<IFuturesDomainService, FuturesDomainService>();

--- a/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
@@ -17,6 +17,7 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
         public DbSet<StakingCoin> StakingCoins { get; set; }
         public DbSet<Staking> Staking { get; set; }
         public DbSet<LogEntry> LogEntries { get; set; }
+        public DbSet<Transfer> Transfers { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -61,6 +62,24 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
                     v => v.Value,
                     v => new Email(v)
                 );
+
+            modelBuilder.Entity<Transfer>()
+                .Property(x => x.Symbol)
+                .HasConversion(
+                    v => v.Value,
+                    v => new CoinSymbol(v)
+                );
+
+            modelBuilder.Entity<Transfer>()
+                .Property(x => x.Code)
+                .HasConversion(
+                    v => v.Value,
+                    v => new VerificationCode(v)
+                );
+
+            modelBuilder.Entity<Transfer>()
+                .Property(x => x.Status)
+                .HasConversion<string>();
         }
     }
 }

--- a/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfTransferRepository.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfTransferRepository.cs
@@ -1,0 +1,30 @@
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CryptocurrencyExchange.Infrastructure.Persistence.Repositories
+{
+    public class EfTransferRepository : ITransferRepository
+    {
+        private readonly DataContext _context;
+
+        public EfTransferRepository(DataContext context)
+        {
+            _context = context;
+        }
+
+        public async Task AddAsync(Transfer transfer)
+        {
+            await _context.Transfers.AddAsync(transfer);
+        }
+
+        public async Task<Transfer?> GetPendingByIdAndSenderAsync(int transferId, int senderId)
+        {
+            return await _context.Transfers
+                .FirstOrDefaultAsync(t =>
+                    t.Id == transferId &&
+                    t.SenderId == senderId &&
+                    t.Status == TransferStatus.Pending);
+        }
+    }
+}

--- a/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/WalletItemRepository.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/WalletItemRepository.cs
@@ -18,6 +18,10 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence.Repositories
         public Task<WalletItem?> GetAsync(int userId, CoinSymbol symbol) =>
             _context.WalletItems.FirstOrDefaultAsync(x => x.UserId == userId && x.Symbol == symbol);
 
+        public Task<WalletItem?> GetWithUserAsync(int userId, CoinSymbol symbol) =>
+            _context.WalletItems.Include(x => x.User)
+                .FirstOrDefaultAsync(x => x.UserId == userId && x.Symbol == symbol);
+
         public async Task AddAsync(WalletItem item)
         {
             await _context.WalletItems.AddAsync(item);
@@ -26,6 +30,19 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence.Repositories
         public Task<List<WalletItem>> GetNonEmptyByUserAsync(int userId)
         {
             return _context.WalletItems.Where(x => x.UserId == userId && x.Amount > 0).ToListAsync();
+        }
+
+        public async Task<(WalletItem? Sender, WalletItem? Receiver)> GetForTransferAsync(
+            int senderId, int receiverId, CoinSymbol symbol)
+        {
+            var items = await _context.WalletItems
+                .Where(x => (x.UserId == senderId || x.UserId == receiverId) && x.Symbol == symbol)
+                .ToListAsync();
+
+            return (
+                items.FirstOrDefault(x => x.UserId == senderId),
+                items.FirstOrDefault(x => x.UserId == receiverId)
+            );
         }
 
         public async Task<TradeWalletItems> GetCoinsDataForTradeAsync(int userId, CoinSymbol coinSymbol)

--- a/CryptocurrencyExchange/Migrations/20260305031145_AddTransfers.Designer.cs
+++ b/CryptocurrencyExchange/Migrations/20260305031145_AddTransfers.Designer.cs
@@ -4,6 +4,7 @@ using CryptocurrencyExchange.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CryptocurrencyExchange.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260305031145_AddTransfers")]
+    partial class AddTransfers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CryptocurrencyExchange/Migrations/20260305031145_AddTransfers.cs
+++ b/CryptocurrencyExchange/Migrations/20260305031145_AddTransfers.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CryptocurrencyExchange.Migrations
+{
+    public partial class AddTransfers : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Transfers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    SenderId = table.Column<int>(type: "int", nullable: false),
+                    ReceiverId = table.Column<int>(type: "int", nullable: false),
+                    Symbol = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Amount = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    Code = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Status = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Transfers", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Transfers");
+        }
+    }
+}

--- a/CryptocurrencyExchange/Presentation/Controllers/TransferController.cs
+++ b/CryptocurrencyExchange/Presentation/Controllers/TransferController.cs
@@ -1,0 +1,34 @@
+using CryptocurrencyExchange.Application.Transfers;
+using CryptocurrencyExchange.Core.Interfaces.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CryptocurrencyExchange.Presentation.Controllers
+{
+    [Authorize]
+    public class TransferController : ApiControllerBase
+    {
+        private readonly ITransferService _transferService;
+
+        public TransferController(ITransferService transferService)
+        {
+            _transferService = transferService;
+        }
+
+        [HttpPost("auth/transfer/initiate")]
+        public async Task<ActionResult<int>> Initiate([FromBody] InitiateTransferDto dto)
+        {
+            var transferId = await _transferService.InitiateAsync(UserId, dto);
+
+            return Ok(transferId);
+        }
+
+        [HttpPost("auth/transfer/confirm")]
+        public async Task<ActionResult> Confirm([FromBody] ConfirmTransferDto dto)
+        {
+            await _transferService.ConfirmAsync(UserId, dto);
+
+            return Ok();
+        }
+    }
+}

--- a/CryptocurrencyExchange/Presentation/Controllers/WalletController.cs
+++ b/CryptocurrencyExchange/Presentation/Controllers/WalletController.cs
@@ -50,13 +50,5 @@ namespace CryptocurrencyExchange.Presentation.Controllers
 
             return Ok();
         }
-
-
-        public class SendCryptoModel
-        {
-            public string symbol { get; set; } = string.Empty;
-            public decimal amount { get; set; }
-            public int receiver { get; set; }
-        }
     }
 }


### PR DESCRIPTION
## **Why:** 
Users need a secure way to transfer coins to each other within the platform. Email verification ensures only the account owner can authorize outgoing transfers.

## **What:**
Two-step transfer flow — user initiates a transfer by specifying receiver email, coin and amount, receives a 6-digit verification code to their email via MassTransit/EmailService, then confirms the transfer by submitting the code. Includes Transfer entity with domain-level code validation and status management, optimized DB queries (single query for sender wallet + user, single query for both wallets on confirm), serializable transactions to prevent double-spend, and full test coverage for domain logic and service layer.

## **Result:** 
`POST auth/transfer/initiate` and `POST auth/transfer/confirm` endpoints, 12 new unit tests passing (46 total).