### PR TITLE
Add transactional outbox for user registration event

### DIFF
--- a/CryptocurrencyExchange.Tests/Infrastructure/OutboxDispatcherTests.cs
+++ b/CryptocurrencyExchange.Tests/Infrastructure/OutboxDispatcherTests.cs
@@ -1,0 +1,78 @@
+using CryptocurrencyExchange.Core.Events;
+using CryptocurrencyExchange.Core.Interfaces;
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using CryptocurrencyExchange.Infrastructure.Outbox;
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+
+namespace CryptocurrencyExchange.Tests.Infrastructure
+{
+    [TestFixture]
+    public class OutboxDispatcherTests
+    {
+        private Mock<IUserRegistrationOutboxRepository> _outboxRepo;
+        private Mock<IPublishEndpoint> _publishEndpoint;
+        private Mock<IUnitOfWork> _uow;
+        private OutboxDispatcher _dispatcher;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _outboxRepo = new Mock<IUserRegistrationOutboxRepository>();
+            _publishEndpoint = new Mock<IPublishEndpoint>();
+            _uow = new Mock<IUnitOfWork>();
+
+            var services = new ServiceCollection();
+            services.AddSingleton(_outboxRepo.Object);
+            services.AddSingleton(_publishEndpoint.Object);
+            services.AddSingleton(_uow.Object);
+
+            var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+            _dispatcher = new OutboxDispatcher(scopeFactory, NullLogger<OutboxDispatcher>.Instance);
+        }
+
+        [Test]
+        public async Task DispatchPendingAsync_WhenNoPendingEntries_DoesNotPublishOrCommit()
+        {
+            _outboxRepo.Setup(x => x.GetPendingAsync()).ReturnsAsync(new List<UserRegistrationOutbox>());
+
+            await _dispatcher.DispatchPendingAsync();
+
+            _publishEndpoint.Verify(
+                x => x.Publish(It.IsAny<UserRegisteredEvent>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            _uow.Verify(x => x.CommitAsync(), Times.Never);
+        }
+
+        [Test]
+        public async Task DispatchPendingAsync_WhenPendingEntriesExist_PublishesAndCommits()
+        {
+            var entry = new UserRegistrationOutbox(42, "user@example.com");
+            _outboxRepo.Setup(x => x.GetPendingAsync()).ReturnsAsync(new List<UserRegistrationOutbox> { entry });
+
+            await _dispatcher.DispatchPendingAsync();
+
+            _publishEndpoint.Verify(
+                x => x.Publish(
+                    It.Is<UserRegisteredEvent>(e => e.UserId == 42 && e.Email == "user@example.com"),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+            _uow.Verify(x => x.CommitAsync(), Times.Once);
+        }
+
+        [Test]
+        public async Task DispatchPendingAsync_WhenPendingEntriesExist_MarksEntriesAsProcessed()
+        {
+            var entry = new UserRegistrationOutbox(42, "user@example.com");
+            _outboxRepo.Setup(x => x.GetPendingAsync()).ReturnsAsync(new List<UserRegistrationOutbox> { entry });
+
+            await _dispatcher.DispatchPendingAsync();
+
+            Assert.That(entry.ProcessedAt, Is.Not.Null);
+        }
+    }
+}

--- a/CryptocurrencyExchange.Tests/ServicesTests/AuthServiceTests.cs
+++ b/CryptocurrencyExchange.Tests/ServicesTests/AuthServiceTests.cs
@@ -1,11 +1,9 @@
 using CryptocurrencyExchange.Application.Auth;
-using CryptocurrencyExchange.Core.Events;
 using CryptocurrencyExchange.Core.Interfaces;
 using CryptocurrencyExchange.Core.Interfaces.Repositories;
 using CryptocurrencyExchange.Core.Models;
 using CryptocurrencyExchange.Core.ValueObject.User;
 using CryptocurrencyExchange.Exceptions;
-using MassTransit;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
@@ -19,7 +17,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         private Mock<IAuthDomainService> _authDomainService;
         private Mock<IUnitOfWork> _uow;
         private Mock<ITokenService> _tokenService;
-        private Mock<IPublishEndpoint> _publishEndpoint;
+        private Mock<IUserRegistrationOutboxRepository> _outboxRepo;
 
         private AuthService _service;
 
@@ -33,7 +31,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
             _authDomainService = new Mock<IAuthDomainService>();
             _uow = new Mock<IUnitOfWork>();
             _tokenService = new Mock<ITokenService>();
-            _publishEndpoint = new Mock<IPublishEndpoint>();
+            _outboxRepo = new Mock<IUserRegistrationOutboxRepository>();
 
             _uow.Setup(x => x.ExecuteInTransactionAsync(It.IsAny<Func<Task>>()))
                 .Returns<Func<Task>>(f => f());
@@ -43,7 +41,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
                 _uow.Object,
                 _authDomainService.Object,
                 _tokenService.Object,
-                _publishEndpoint.Object,
+                _outboxRepo.Object,
                 NullLogger<AuthService>.Instance
             );
         }
@@ -91,7 +89,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         }
 
         [Test]
-        public async Task RegisterAsync_WhenNewUser_CreatesUserAndPublishesEvent()
+        public async Task RegisterAsync_WhenNewUser_CreatesUserAndWritesOutboxEntry()
         {
             var user = CreateTestUser();
             _userRepo.Setup(x => x.UserExists(TestEmailVo)).ReturnsAsync(false);
@@ -101,8 +99,9 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
 
             _userRepo.Verify(x => x.AddUserAsync(user), Times.Once);
             _uow.Verify(x => x.ExecuteInTransactionAsync(It.IsAny<Func<Task>>()), Times.Once);
-            _publishEndpoint.Verify(
-                x => x.Publish(It.IsAny<UserRegisteredEvent>(), It.IsAny<CancellationToken>()),
+            _outboxRepo.Verify(
+                x => x.AddAsync(It.Is<UserRegistrationOutbox>(e =>
+                    e.UserId == user.Id && e.Email == user.Email.Value)),
                 Times.Once);
         }
 

--- a/CryptocurrencyExchange/Application/Auth/AuthService.cs
+++ b/CryptocurrencyExchange/Application/Auth/AuthService.cs
@@ -1,11 +1,9 @@
-using CryptocurrencyExchange.Core.Events;
 using CryptocurrencyExchange.Core.Interfaces;
 using CryptocurrencyExchange.Core.Interfaces.Repositories;
 using CryptocurrencyExchange.Core.Interfaces.Services;
 using CryptocurrencyExchange.Core.Models;
 using CryptocurrencyExchange.Core.ValueObject.User;
 using CryptocurrencyExchange.Exceptions;
-using MassTransit;
 
 namespace CryptocurrencyExchange.Application.Auth
 {
@@ -15,7 +13,7 @@ namespace CryptocurrencyExchange.Application.Auth
         private readonly IAuthDomainService _authDomainService;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ITokenService _tokenService;
-        private readonly IPublishEndpoint _publishEndpoint;
+        private readonly IUserRegistrationOutboxRepository _outboxRepository;
         private readonly ILogger<AuthService> _logger;
 
         public AuthService(
@@ -23,14 +21,14 @@ namespace CryptocurrencyExchange.Application.Auth
             IUnitOfWork unitOfWork,
             IAuthDomainService authDomainService,
             ITokenService tokenService,
-            IPublishEndpoint publishEndpoint,
+            IUserRegistrationOutboxRepository outboxRepository,
             ILogger<AuthService> logger)
         {
             _userRepository = userRepository;
             _unitOfWork = unitOfWork;
             _authDomainService = authDomainService;
             _tokenService = tokenService;
-            _publishEndpoint = publishEndpoint;
+            _outboxRepository = outboxRepository;
             _logger = logger;
         }
 
@@ -67,9 +65,8 @@ namespace CryptocurrencyExchange.Application.Auth
             {
                 user = _authDomainService.CreateUser(email, password);
                 await _userRepository.AddUserAsync(user);
+                await _outboxRepository.AddAsync(new UserRegistrationOutbox(user.Id, user.Email));
             });
-
-            await _publishEndpoint.Publish(new UserRegisteredEvent(user.Id, user.Email));
 
             _logger.LogInformation("New user registered with email {Email}", email.Value);
         }

--- a/CryptocurrencyExchange/Core/Entities/UserRegistrationOutbox.cs
+++ b/CryptocurrencyExchange/Core/Entities/UserRegistrationOutbox.cs
@@ -1,0 +1,22 @@
+namespace CryptocurrencyExchange.Core.Models
+{
+    public class UserRegistrationOutbox
+    {
+        public int Id { get; private set; }
+        public int UserId { get; private set; }
+        public string Email { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+        public DateTime? ProcessedAt { get; private set; }
+
+        private UserRegistrationOutbox() { }
+
+        public UserRegistrationOutbox(int userId, string email)
+        {
+            UserId = userId;
+            Email = email;
+            CreatedAt = DateTime.UtcNow;
+        }
+
+        public void MarkProcessed() => ProcessedAt = DateTime.UtcNow;
+    }
+}

--- a/CryptocurrencyExchange/Core/Interfaces/Repositories/IUserRegistrationOutboxRepository.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Repositories/IUserRegistrationOutboxRepository.cs
@@ -1,0 +1,10 @@
+using CryptocurrencyExchange.Core.Models;
+
+namespace CryptocurrencyExchange.Core.Interfaces.Repositories
+{
+    public interface IUserRegistrationOutboxRepository
+    {
+        Task AddAsync(UserRegistrationOutbox entry);
+        Task<List<UserRegistrationOutbox>> GetPendingAsync();
+    }
+}

--- a/CryptocurrencyExchange/Extensions/InfrastructureCollectionExtensions.cs
+++ b/CryptocurrencyExchange/Extensions/InfrastructureCollectionExtensions.cs
@@ -7,6 +7,7 @@ using CryptocurrencyExchange.Infrastructure.News;
 using CryptocurrencyExchange.Infrastructure.Persistence;
 using CryptocurrencyExchange.Infrastructure.Persistence.Repositories;
 using CryptocurrencyExchange.Infrastructure.Schedulers;
+using CryptocurrencyExchange.Infrastructure.Outbox;
 using CryptocurrencyExchange.Infrastructure.Wallets;
 using CryptocurrencyExchange.Options;
 using MassTransit;
@@ -38,6 +39,7 @@ namespace CryptocurrencyExchange.Extensions
             services.AddScoped<ICryptoNewsRepository, NewPersistence>();
             services.AddScoped<IUserRepository, EfUserRepository>();
             services.AddScoped<ITransferRepository, EfTransferRepository>();
+            services.AddScoped<IUserRegistrationOutboxRepository, EfUserRegistrationOutboxRepository>();
             services.AddScoped<IDatabaseHealthChecker, EfDatabaseHealthChecker>();
 
             return services;
@@ -132,6 +134,7 @@ namespace CryptocurrencyExchange.Extensions
         public static IServiceCollection AddBackgroundJobs(this IServiceCollection services)
         {
             services.AddHostedService<StakingScheduler>();
+            services.AddHostedService<OutboxDispatcher>();
             return services;
         }
 

--- a/CryptocurrencyExchange/Infrastructure/Outbox/OutboxDispatcher.cs
+++ b/CryptocurrencyExchange/Infrastructure/Outbox/OutboxDispatcher.cs
@@ -1,0 +1,48 @@
+using CryptocurrencyExchange.Core.Events;
+using CryptocurrencyExchange.Core.Interfaces;
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using MassTransit;
+
+namespace CryptocurrencyExchange.Infrastructure.Outbox
+{
+    public class OutboxDispatcher : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<OutboxDispatcher> _logger;
+
+        public OutboxDispatcher(IServiceScopeFactory scopeFactory, ILogger<OutboxDispatcher> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await DispatchPendingAsync();
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
+        }
+
+        internal async Task DispatchPendingAsync()
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var outboxRepository = scope.ServiceProvider.GetRequiredService<IUserRegistrationOutboxRepository>();
+            var publishEndpoint = scope.ServiceProvider.GetRequiredService<IPublishEndpoint>();
+            var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var pending = await outboxRepository.GetPendingAsync();
+            if (pending.Count == 0) return;
+
+            foreach (var entry in pending)
+            {
+                await publishEndpoint.Publish(new UserRegisteredEvent(entry.UserId, entry.Email));
+                entry.MarkProcessed();
+            }
+
+            await unitOfWork.CommitAsync();
+            _logger.LogInformation("Dispatched {Count} registration outbox entries", pending.Count);
+        }
+    }
+}

--- a/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
@@ -18,6 +18,7 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
         public DbSet<Staking> Staking { get; set; }
         public DbSet<LogEntry> LogEntries { get; set; }
         public DbSet<Transfer> Transfers { get; set; }
+        public DbSet<UserRegistrationOutbox> UserRegistrationOutbox { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -26,6 +27,7 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
             ConfigureUser(modelBuilder);
             ConfigureFuture(modelBuilder);
             ConfigureLogEntry(modelBuilder);
+            ConfigureUserRegistrationOutbox(modelBuilder);
         }
 
         private static void ConfigureFuture(ModelBuilder modelBuilder)
@@ -90,6 +92,16 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
                 b.Property(e => e.TimestampUtc).IsRequired();
                 b.HasIndex(e => e.TimestampUtc);
                 b.HasIndex(e => e.Level);
+            });
+        }
+
+        private static void ConfigureUserRegistrationOutbox(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<UserRegistrationOutbox>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Email).IsRequired().HasMaxLength(256);
+                b.HasIndex(e => e.ProcessedAt);
             });
         }
 

--- a/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfUserRegistrationOutboxRepository.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfUserRegistrationOutboxRepository.cs
@@ -1,0 +1,22 @@
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CryptocurrencyExchange.Infrastructure.Persistence.Repositories
+{
+    public class EfUserRegistrationOutboxRepository : IUserRegistrationOutboxRepository
+    {
+        private readonly DataContext _context;
+
+        public EfUserRegistrationOutboxRepository(DataContext context)
+            => _context = context;
+
+        public async Task AddAsync(UserRegistrationOutbox entry)
+            => await _context.UserRegistrationOutbox.AddAsync(entry);
+
+        public async Task<List<UserRegistrationOutbox>> GetPendingAsync()
+            => await _context.UserRegistrationOutbox
+                .Where(e => e.ProcessedAt == null)
+                .ToListAsync();
+    }
+}

--- a/CryptocurrencyExchange/Migrations/20260502103657_AddUserRegistrationOutbox.Designer.cs
+++ b/CryptocurrencyExchange/Migrations/20260502103657_AddUserRegistrationOutbox.Designer.cs
@@ -4,6 +4,7 @@ using CryptocurrencyExchange.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CryptocurrencyExchange.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260502103657_AddUserRegistrationOutbox")]
+    partial class AddUserRegistrationOutbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CryptocurrencyExchange/Migrations/20260502103657_AddUserRegistrationOutbox.cs
+++ b/CryptocurrencyExchange/Migrations/20260502103657_AddUserRegistrationOutbox.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CryptocurrencyExchange.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserRegistrationOutbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserRegistrationOutbox",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ProcessedAt = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserRegistrationOutbox", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserRegistrationOutbox_ProcessedAt",
+                table: "UserRegistrationOutbox",
+                column: "ProcessedAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserRegistrationOutbox");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes dual-write bug in `AuthService.RegisterAsync` where `UserRegisteredEvent` was published outside the DB transaction — a crash between commit and publish left users without a starter wallet or welcome email
- Adds `UserRegistrationOutbox` table written atomically with the user row in the same transaction
- Adds `OutboxDispatcher` background service that polls every 5s, publishes pending entries to RabbitMQ, and marks them processed

## Test plan
- All 67 existing tests pass
- New `OutboxDispatcherTests` covers: empty queue (no publish/commit), pending entries (publishes + commits), and `MarkProcessed` called on each entry
- Updated `AuthServiceTests` verifies outbox row is written instead of direct publish