### PR TITLE
Add idempotency to transfer initiation and confirmation

### DIFF
--- a/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
+++ b/CryptocurrencyExchange.Tests/ServicesTests/TransferServiceTests.cs
@@ -5,6 +5,8 @@ using CryptocurrencyExchange.Core.Models;
 using CryptocurrencyExchange.Core.ValueObject;
 using CryptocurrencyExchange.Core.ValueObject.User;
 using CryptocurrencyExchange.Exceptions;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
@@ -19,11 +21,13 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         private Mock<IUserRepository> _userRepo;
         private Mock<IUnitOfWork> _uow;
         private Mock<ITransferVerificationOutboxRepository> _outboxRepo;
+        private Mock<ITransferIdempotentRequestRepository> _idempotentRepo;
 
         private TransferService _service;
 
         private const int SenderId = 1;
         private const int ReceiverId = 2;
+        private const string IdempotencyKey = "test-key-123";
         private static readonly Email SenderEmail = new("sender@test.com");
         private static readonly Email ReceiverEmail = new("receiver@test.com");
 
@@ -35,6 +39,7 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
             _userRepo = new Mock<IUserRepository>();
             _uow = new Mock<IUnitOfWork>();
             _outboxRepo = new Mock<ITransferVerificationOutboxRepository>();
+            _idempotentRepo = new Mock<ITransferIdempotentRequestRepository>();
 
             _uow.Setup(x => x.ExecuteInTransactionAsync(It.IsAny<Func<Task>>()))
                 .Returns<Func<Task>>(f => f());
@@ -45,13 +50,52 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
                 _userRepo.Object,
                 _uow.Object,
                 _outboxRepo.Object,
+                _idempotentRepo.Object,
                 NullLogger<TransferService>.Instance
             );
         }
 
         [Test]
-        public async Task InitiateAsync_ValidRequest_ShouldCreateTransferAndWriteOutboxEntry()
+        public async Task InitiateAsync_NewKey_ShouldCreateTransferAndWriteOutboxEntry()
         {
+            var receiver = new User(ReceiverEmail, new byte[] { 1 }, new byte[] { 2 });
+            var senderItem = new WalletItem(SenderId, CoinSymbol.Btc);
+            senderItem.AddAmount(10m);
+            SetUserProperty(senderItem, new User(SenderEmail, new byte[] { 3 }, new byte[] { 4 }));
+
+            _idempotentRepo.Setup(x => x.FindAsync(IdempotencyKey, SenderId)).ReturnsAsync((TransferIdempotentRequest)null);
+            _userRepo.Setup(x => x.GetByEmailAsync(ReceiverEmail)).ReturnsAsync(receiver);
+            _walletRepo.Setup(x => x.GetWithUserAsync(SenderId, CoinSymbol.Btc)).ReturnsAsync(senderItem);
+
+            var dto = new InitiateTransferDto(ReceiverEmail, "btc", 5m);
+            await _service.InitiateAsync(SenderId, dto, IdempotencyKey);
+
+            _transferRepo.Verify(x => x.AddAsync(It.IsAny<Transfer>()), Times.Once);
+            _outboxRepo.Verify(
+                x => x.AddAsync(It.Is<TransferVerificationOutbox>(e => e.Email == SenderEmail.Value)),
+                Times.Once);
+            _idempotentRepo.Verify(x => x.AddAsync(It.IsAny<TransferIdempotentRequest>()), Times.Once);
+        }
+
+        [Test]
+        public async Task InitiateAsync_ExistingValidKey_ShouldReturnCachedTransferIdWithoutCreatingTransfer()
+        {
+            var existingRequest = CreateIdempotentRequest(IdempotencyKey, SenderId, transferId: 42);
+            _idempotentRepo.Setup(x => x.FindAsync(IdempotencyKey, SenderId)).ReturnsAsync(existingRequest);
+
+            var dto = new InitiateTransferDto(ReceiverEmail, "btc", 5m);
+            var result = await _service.InitiateAsync(SenderId, dto, IdempotencyKey);
+
+            Assert.That(result, Is.EqualTo(42));
+            _transferRepo.Verify(x => x.AddAsync(It.IsAny<Transfer>()), Times.Never);
+            _outboxRepo.Verify(x => x.AddAsync(It.IsAny<TransferVerificationOutbox>()), Times.Never);
+        }
+
+        [Test]
+        public async Task InitiateAsync_ConcurrentConflict_ShouldReturnExistingTransferId()
+        {
+            _idempotentRepo.Setup(x => x.FindAsync(IdempotencyKey, SenderId)).ReturnsAsync((TransferIdempotentRequest)null);
+
             var receiver = new User(ReceiverEmail, new byte[] { 1 }, new byte[] { 2 });
             var senderItem = new WalletItem(SenderId, CoinSymbol.Btc);
             senderItem.AddAmount(10m);
@@ -60,36 +104,41 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
             _userRepo.Setup(x => x.GetByEmailAsync(ReceiverEmail)).ReturnsAsync(receiver);
             _walletRepo.Setup(x => x.GetWithUserAsync(SenderId, CoinSymbol.Btc)).ReturnsAsync(senderItem);
 
-            var dto = new InitiateTransferDto(ReceiverEmail, "btc", 5m);
-            var transferId = await _service.InitiateAsync(SenderId, dto);
+            _uow.Setup(x => x.ExecuteInTransactionAsync(It.IsAny<Func<Task>>()))
+                .ThrowsAsync(new DbUpdateException("duplicate key", MakeDuplicateKeySqlException()));
 
-            _transferRepo.Verify(x => x.AddAsync(It.IsAny<Transfer>()), Times.Once);
-            _outboxRepo.Verify(
-                x => x.AddAsync(It.Is<TransferVerificationOutbox>(e => e.Email == SenderEmail.Value)),
-                Times.Once);
+            var conflictRecord = CreateIdempotentRequest(IdempotencyKey, SenderId, transferId: 99);
+            _idempotentRepo.Setup(x => x.FindAsync(IdempotencyKey, SenderId)).ReturnsAsync(conflictRecord);
+
+            var dto = new InitiateTransferDto(ReceiverEmail, "btc", 5m);
+            var result = await _service.InitiateAsync(SenderId, dto, IdempotencyKey);
+
+            Assert.That(result, Is.EqualTo(99));
         }
 
         [Test]
         public void InitiateAsync_ReceiverNotFound_ShouldThrowUserNotFoundException()
         {
+            _idempotentRepo.Setup(x => x.FindAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync((TransferIdempotentRequest)null);
             _userRepo.Setup(x => x.GetByEmailAsync(It.IsAny<string>())).ReturnsAsync((User)null);
 
             var dto = new InitiateTransferDto("unknown@test.com", "btc", 5m);
 
             Assert.ThrowsAsync<UserNotFoundException>(async () =>
-                await _service.InitiateAsync(SenderId, dto));
+                await _service.InitiateAsync(SenderId, dto, IdempotencyKey));
         }
 
         [Test]
         public void InitiateAsync_SelfTransfer_ShouldThrowSelfTransferException()
         {
             var sender = new User(SenderEmail, new byte[] { 1 }, new byte[] { 2 });
+            _idempotentRepo.Setup(x => x.FindAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync((TransferIdempotentRequest)null);
             _userRepo.Setup(x => x.GetByEmailAsync(SenderEmail)).ReturnsAsync(sender);
 
             var dto = new InitiateTransferDto(SenderEmail, "btc", 5m);
 
             Assert.ThrowsAsync<SelfTransferException>(async () =>
-                await _service.InitiateAsync(sender.Id, dto));
+                await _service.InitiateAsync(sender.Id, dto, IdempotencyKey));
         }
 
         [Test]
@@ -100,26 +149,28 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
             senderItem.AddAmount(1m);
             SetUserProperty(senderItem, new User(SenderEmail, new byte[] { 3 }, new byte[] { 4 }));
 
+            _idempotentRepo.Setup(x => x.FindAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync((TransferIdempotentRequest)null);
             _userRepo.Setup(x => x.GetByEmailAsync(ReceiverEmail)).ReturnsAsync(receiver);
             _walletRepo.Setup(x => x.GetWithUserAsync(SenderId, CoinSymbol.Btc)).ReturnsAsync(senderItem);
 
             var dto = new InitiateTransferDto(ReceiverEmail, "btc", 10m);
 
             Assert.ThrowsAsync<InsufficientFundsException>(async () =>
-                await _service.InitiateAsync(SenderId, dto));
+                await _service.InitiateAsync(SenderId, dto, IdempotencyKey));
         }
 
         [Test]
         public void InitiateAsync_SenderHasNoWalletItem_ShouldThrowWalletItemNotFoundException()
         {
             var receiver = new User(ReceiverEmail, new byte[] { 1 }, new byte[] { 2 });
+            _idempotentRepo.Setup(x => x.FindAsync(It.IsAny<string>(), It.IsAny<int>())).ReturnsAsync((TransferIdempotentRequest)null);
             _userRepo.Setup(x => x.GetByEmailAsync(ReceiverEmail)).ReturnsAsync(receiver);
             _walletRepo.Setup(x => x.GetWithUserAsync(SenderId, CoinSymbol.Btc)).ReturnsAsync((WalletItem)null);
 
             var dto = new InitiateTransferDto(ReceiverEmail, "btc", 5m);
 
             Assert.ThrowsAsync<WalletItemNotFoundException>(async () =>
-                await _service.InitiateAsync(SenderId, dto));
+                await _service.InitiateAsync(SenderId, dto, IdempotencyKey));
         }
 
         [Test]
@@ -142,10 +193,23 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
         }
 
         [Test]
+        public async Task ConfirmAsync_AlreadyCompleted_ShouldReturnWithoutError()
+        {
+            var completed = Transfer.Create(SenderId, ReceiverId, CoinSymbol.Btc, 5m, "123456");
+
+            _transferRepo.Setup(x => x.GetPendingByIdAndSenderAsync(0, SenderId)).ReturnsAsync((Transfer)null);
+            _transferRepo.Setup(x => x.GetCompletedByIdAndSenderAsync(0, SenderId)).ReturnsAsync(completed);
+
+            var dto = new ConfirmTransferDto(0, "123456");
+
+            Assert.DoesNotThrowAsync(async () => await _service.ConfirmAsync(SenderId, dto));
+        }
+
+        [Test]
         public void ConfirmAsync_TransferNotFound_ShouldThrowTransferNotFoundException()
         {
-            _transferRepo.Setup(x => x.GetPendingByIdAndSenderAsync(99, SenderId))
-                .ReturnsAsync((Transfer)null);
+            _transferRepo.Setup(x => x.GetPendingByIdAndSenderAsync(99, SenderId)).ReturnsAsync((Transfer)null);
+            _transferRepo.Setup(x => x.GetCompletedByIdAndSenderAsync(99, SenderId)).ReturnsAsync((Transfer)null);
 
             var dto = new ConfirmTransferDto(99, "123456");
 
@@ -187,10 +251,28 @@ namespace CryptocurrencyExchange.Tests.ServicesTests
             Assert.That(senderItem.Amount.Value, Is.EqualTo(5m));
         }
 
+        private static TransferIdempotentRequest CreateIdempotentRequest(string key, int userId, int transferId)
+        {
+            var request = new TransferIdempotentRequest(key, userId);
+            request.SetTransferId(transferId);
+            return request;
+        }
+
         private static void SetUserProperty(WalletItem item, User user)
         {
             var prop = typeof(WalletItem).GetProperty("User");
             prop!.SetValue(item, user);
+        }
+
+        private static SqlException MakeDuplicateKeySqlException()
+        {
+            var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+            var collection = (SqlErrorCollection)Activator.CreateInstance(typeof(SqlErrorCollection), nonPublic: true)!;
+            var errorCtor = typeof(SqlError).GetConstructors(flags).First(c => c.GetParameters().Length == 8);
+            var error = (SqlError)errorCtor.Invoke(new object?[] { 2627, (byte)0, (byte)0, "server", "duplicate key", "proc", 0, null });
+            typeof(SqlErrorCollection).GetMethod("Add", flags)!.Invoke(collection, new object[] { error });
+            return (SqlException)typeof(SqlException).GetConstructors(flags)[0]
+                .Invoke(new object?[] { "duplicate key", collection, null, Guid.NewGuid() });
         }
     }
 }

--- a/CryptocurrencyExchange/Application/Transfer/TransferService.cs
+++ b/CryptocurrencyExchange/Application/Transfer/TransferService.cs
@@ -4,6 +4,8 @@ using CryptocurrencyExchange.Core.Interfaces.Services;
 using CryptocurrencyExchange.Core.Models;
 using CryptocurrencyExchange.Core.ValueObject;
 using CryptocurrencyExchange.Exceptions;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
 
 namespace CryptocurrencyExchange.Application.Transfers
 {
@@ -14,6 +16,7 @@ namespace CryptocurrencyExchange.Application.Transfers
         private readonly IUserRepository _userRepository;
         private readonly IUnitOfWork _unitOfWork;
         private readonly ITransferVerificationOutboxRepository _outboxRepository;
+        private readonly ITransferIdempotentRequestRepository _idempotentRequestRepository;
         private readonly ILogger<TransferService> _logger;
 
         public TransferService(
@@ -22,6 +25,7 @@ namespace CryptocurrencyExchange.Application.Transfers
             IUserRepository userRepository,
             IUnitOfWork unitOfWork,
             ITransferVerificationOutboxRepository outboxRepository,
+            ITransferIdempotentRequestRepository idempotentRequestRepository,
             ILogger<TransferService> logger)
         {
             _transferRepository = transferRepository;
@@ -29,11 +33,16 @@ namespace CryptocurrencyExchange.Application.Transfers
             _userRepository = userRepository;
             _unitOfWork = unitOfWork;
             _outboxRepository = outboxRepository;
+            _idempotentRequestRepository = idempotentRequestRepository;
             _logger = logger;
         }
 
-        public async Task<int> InitiateAsync(int senderId, InitiateTransferDto dto)
+        public async Task<int> InitiateAsync(int senderId, InitiateTransferDto dto, string idempotencyKey)
         {
+            var existing = await _idempotentRequestRepository.FindAsync(idempotencyKey, senderId);
+            if (existing is not null && !existing.IsExpired && existing.TransferId.HasValue)
+                return existing.TransferId.Value;
+
             var receiver = await _userRepository.GetByEmailAsync(dto.ReceiverEmail)
                 ?? throw new UserNotFoundException();
 
@@ -49,16 +58,30 @@ namespace CryptocurrencyExchange.Application.Transfers
                 throw new InsufficientFundsException();
 
             var code = GenerateCode();
+            var idempotentRequest = new TransferIdempotentRequest(idempotencyKey, senderId);
             Transfer transfer = null;
 
-            await _unitOfWork.ExecuteInTransactionAsync(async () =>
+            try
             {
-                transfer = Transfer.Create(senderId, receiver.Id, symbol, dto.Amount, code);
-                await _transferRepository.AddAsync(transfer);
-                await _outboxRepository.AddAsync(new TransferVerificationOutbox(senderItem.User.Email, code));
-            });
+                await _unitOfWork.ExecuteInTransactionAsync(async () =>
+                {
+                    await _idempotentRequestRepository.AddAsync(idempotentRequest);
+                    transfer = Transfer.Create(senderId, receiver.Id, symbol, dto.Amount, code);
+                    await _transferRepository.AddAsync(transfer);
+                    await _outboxRepository.AddAsync(new TransferVerificationOutbox(senderItem.User.Email, code));
+                    await _unitOfWork.CommitAsync();
+                    idempotentRequest.SetTransferId(transfer.Id);
+                });
+            }
+            catch (DbUpdateException ex) when (IsDuplicateKeyException(ex))
+            {
+                var conflict = await _idempotentRequestRepository.FindAsync(idempotencyKey, senderId);
+                if (conflict?.TransferId.HasValue == true)
+                    return conflict.TransferId.Value;
+                throw;
+            }
 
-            _logger.LogInformation("Transfer {TransferId} initiated by user {SenderId}", transfer.Id, senderId);
+            _logger.LogInformation("Transfer {TransferId} initiated by user {SenderId}", transfer!.Id, senderId);
 
             return transfer.Id;
         }
@@ -67,8 +90,16 @@ namespace CryptocurrencyExchange.Application.Transfers
         {
             var codeVo = new VerificationCode(dto.VerificationCode);
 
-            var transfer = await _transferRepository.GetPendingByIdAndSenderAsync(dto.TransferId, senderId)
-                ?? throw new TransferNotFoundException();
+            var transfer = await _transferRepository.GetPendingByIdAndSenderAsync(dto.TransferId, senderId);
+
+            if (transfer is null)
+            {
+                var completed = await _transferRepository.GetCompletedByIdAndSenderAsync(dto.TransferId, senderId);
+                if (completed is not null)
+                    return;
+
+                throw new TransferNotFoundException();
+            }
 
             await _unitOfWork.ExecuteInTransactionAsync(async () =>
             {
@@ -91,5 +122,9 @@ namespace CryptocurrencyExchange.Application.Transfers
         }
 
         private static string GenerateCode() => Random.Shared.Next(100_000, 1_000_000).ToString();
+
+        private static bool IsDuplicateKeyException(DbUpdateException ex) =>
+            ex.InnerException is SqlException sqlEx &&
+            (sqlEx.Number == 2627 || sqlEx.Number == 2601);
     }
 }

--- a/CryptocurrencyExchange/Core/Entities/TransferIdempotentRequest.cs
+++ b/CryptocurrencyExchange/Core/Entities/TransferIdempotentRequest.cs
@@ -1,0 +1,26 @@
+namespace CryptocurrencyExchange.Core.Models
+{
+    public class TransferIdempotentRequest
+    {
+        public int Id { get; private set; }
+        public string Key { get; private set; }
+        public int UserId { get; private set; }
+        public int? TransferId { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+        public DateTime ExpiresAt { get; private set; }
+
+        public bool IsExpired => DateTime.UtcNow > ExpiresAt;
+
+        private TransferIdempotentRequest() { }
+
+        public TransferIdempotentRequest(string key, int userId)
+        {
+            Key = key;
+            UserId = userId;
+            CreatedAt = DateTime.UtcNow;
+            ExpiresAt = DateTime.UtcNow.AddHours(24);
+        }
+
+        public void SetTransferId(int transferId) => TransferId = transferId;
+    }
+}

--- a/CryptocurrencyExchange/Core/Interfaces/Repositories/ITransferIdempotentRequestRepository.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Repositories/ITransferIdempotentRequestRepository.cs
@@ -1,0 +1,10 @@
+using CryptocurrencyExchange.Core.Models;
+
+namespace CryptocurrencyExchange.Core.Interfaces.Repositories
+{
+    public interface ITransferIdempotentRequestRepository
+    {
+        Task<TransferIdempotentRequest?> FindAsync(string key, int userId);
+        Task AddAsync(TransferIdempotentRequest request);
+    }
+}

--- a/CryptocurrencyExchange/Core/Interfaces/Repositories/ITransferRepository.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Repositories/ITransferRepository.cs
@@ -6,5 +6,6 @@ namespace CryptocurrencyExchange.Core.Interfaces.Repositories
     {
         Task AddAsync(Transfer transfer);
         Task<Transfer?> GetPendingByIdAndSenderAsync(int transferId, int senderId);
+        Task<Transfer?> GetCompletedByIdAndSenderAsync(int transferId, int senderId);
     }
 }

--- a/CryptocurrencyExchange/Core/Interfaces/Services/ITransferService.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Services/ITransferService.cs
@@ -4,7 +4,7 @@ namespace CryptocurrencyExchange.Core.Interfaces.Services
 {
     public interface ITransferService
     {
-        Task<int> InitiateAsync(int senderId, InitiateTransferDto dto);
+        Task<int> InitiateAsync(int senderId, InitiateTransferDto dto, string idempotencyKey);
         Task ConfirmAsync(int senderId, ConfirmTransferDto dto);
     }
 }

--- a/CryptocurrencyExchange/Extensions/InfrastructureCollectionExtensions.cs
+++ b/CryptocurrencyExchange/Extensions/InfrastructureCollectionExtensions.cs
@@ -41,6 +41,7 @@ namespace CryptocurrencyExchange.Extensions
             services.AddScoped<ITransferRepository, EfTransferRepository>();
             services.AddScoped<IUserRegistrationOutboxRepository, EfUserRegistrationOutboxRepository>();
             services.AddScoped<ITransferVerificationOutboxRepository, EfTransferVerificationOutboxRepository>();
+            services.AddScoped<ITransferIdempotentRequestRepository, EfTransferIdempotentRequestRepository>();
             services.AddScoped<IDatabaseHealthChecker, EfDatabaseHealthChecker>();
 
             return services;

--- a/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
@@ -20,6 +20,7 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
         public DbSet<Transfer> Transfers { get; set; }
         public DbSet<UserRegistrationOutbox> UserRegistrationOutbox { get; set; }
         public DbSet<TransferVerificationOutbox> TransferVerificationOutbox { get; set; }
+        public DbSet<TransferIdempotentRequest> TransferIdempotentRequests { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -30,6 +31,7 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
             ConfigureLogEntry(modelBuilder);
             ConfigureUserRegistrationOutbox(modelBuilder);
             ConfigureTransferVerificationOutbox(modelBuilder);
+            ConfigureTransferIdempotentRequest(modelBuilder);
         }
 
         private static void ConfigureFuture(ModelBuilder modelBuilder)
@@ -115,6 +117,16 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
                 b.Property(e => e.Email).IsRequired().HasMaxLength(256);
                 b.Property(e => e.VerificationCode).IsRequired().HasMaxLength(6);
                 b.HasIndex(e => e.ProcessedAt);
+            });
+        }
+
+        private static void ConfigureTransferIdempotentRequest(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TransferIdempotentRequest>(b =>
+            {
+                b.HasKey(r => r.Id);
+                b.Property(r => r.Key).IsRequired().HasMaxLength(128);
+                b.HasIndex(r => new { r.Key, r.UserId }).IsUnique();
             });
         }
 

--- a/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfTransferIdempotentRequestRepository.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfTransferIdempotentRequestRepository.cs
@@ -1,0 +1,27 @@
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CryptocurrencyExchange.Infrastructure.Persistence.Repositories
+{
+    public class EfTransferIdempotentRequestRepository : ITransferIdempotentRequestRepository
+    {
+        private readonly DataContext _context;
+
+        public EfTransferIdempotentRequestRepository(DataContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<TransferIdempotentRequest?> FindAsync(string key, int userId)
+        {
+            return await _context.TransferIdempotentRequests
+                .FirstOrDefaultAsync(r => r.Key == key && r.UserId == userId);
+        }
+
+        public async Task AddAsync(TransferIdempotentRequest request)
+        {
+            await _context.TransferIdempotentRequests.AddAsync(request);
+        }
+    }
+}

--- a/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfTransferRepository.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfTransferRepository.cs
@@ -26,5 +26,14 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence.Repositories
                     t.SenderId == senderId &&
                     t.Status == TransferStatus.Pending);
         }
+
+        public async Task<Transfer?> GetCompletedByIdAndSenderAsync(int transferId, int senderId)
+        {
+            return await _context.Transfers
+                .FirstOrDefaultAsync(t =>
+                    t.Id == transferId &&
+                    t.SenderId == senderId &&
+                    t.Status == TransferStatus.Completed);
+        }
     }
 }

--- a/CryptocurrencyExchange/Migrations/20260502181749_AddTransferIdempotentRequests.Designer.cs
+++ b/CryptocurrencyExchange/Migrations/20260502181749_AddTransferIdempotentRequests.Designer.cs
@@ -4,6 +4,7 @@ using CryptocurrencyExchange.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CryptocurrencyExchange.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260502181749_AddTransferIdempotentRequests")]
+    partial class AddTransferIdempotentRequests
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CryptocurrencyExchange/Migrations/20260502181749_AddTransferIdempotentRequests.cs
+++ b/CryptocurrencyExchange/Migrations/20260502181749_AddTransferIdempotentRequests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CryptocurrencyExchange.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTransferIdempotentRequests : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TransferIdempotentRequests",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Key = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    TransferId = table.Column<int>(type: "int", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TransferIdempotentRequests", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TransferIdempotentRequests_Key_UserId",
+                table: "TransferIdempotentRequests",
+                columns: new[] { "Key", "UserId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TransferIdempotentRequests");
+        }
+    }
+}

--- a/CryptocurrencyExchange/Presentation/Controllers/TransferController.cs
+++ b/CryptocurrencyExchange/Presentation/Controllers/TransferController.cs
@@ -18,7 +18,10 @@ namespace CryptocurrencyExchange.Presentation.Controllers
         [HttpPost("auth/transfer/initiate")]
         public async Task<ActionResult<int>> Initiate([FromBody] InitiateTransferDto dto)
         {
-            var transferId = await _transferService.InitiateAsync(UserId, dto);
+            if (!Request.Headers.TryGetValue("Idempotency-Key", out var key) || string.IsNullOrWhiteSpace(key))
+                return BadRequest("Idempotency-Key header is required.");
+
+            var transferId = await _transferService.InitiateAsync(UserId, dto, key.ToString());
 
             return Ok(transferId);
         }


### PR DESCRIPTION
Prevents duplicate transfers when clients retry failed requests.

- `POST /auth/transfer/initiate` requires an `Idempotency-Key` header; retries within 24h return the same transfer ID without creating a new transfer
- `POST /auth/transfer/confirm` returns 200 silently if the transfer is already completed
- Adds `TransferIdempotentRequests` table with a unique constraint on `(Key, UserId)` to guarantee safety under concurrent retries