### PR TITLE
Add API key authentication

### DIFF
--- a/CryptocurrencyExchange.Tests/Infrastructure/ApiKeyAuthenticationHandlerTests.cs
+++ b/CryptocurrencyExchange.Tests/Infrastructure/ApiKeyAuthenticationHandlerTests.cs
@@ -1,0 +1,84 @@
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using CryptocurrencyExchange.Infrastructure.Security;
+using CryptocurrencyExchange.Options;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+
+namespace CryptocurrencyExchange.Tests.Infrastructure
+{
+    [TestFixture]
+    public class ApiKeyAuthenticationHandlerTests
+    {
+        private Mock<IApiKeyRepository> _apiKeyRepo;
+        private Mock<IOptionsMonitor<ApiKeyAuthenticationOptions>> _options;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _apiKeyRepo = new Mock<IApiKeyRepository>();
+            _options = new Mock<IOptionsMonitor<ApiKeyAuthenticationOptions>>();
+            _options.Setup(x => x.Get(It.IsAny<string>())).Returns(new ApiKeyAuthenticationOptions());
+        }
+
+        private async Task<(ApiKeyAuthenticationHandler handler, DefaultHttpContext context)> CreateHandlerAsync()
+        {
+            var context = new DefaultHttpContext();
+            var handler = new ApiKeyAuthenticationHandler(
+                _options.Object,
+                NullLoggerFactory.Instance,
+                UrlEncoder.Default,
+                new SystemClock(),
+                _apiKeyRepo.Object);
+
+            var scheme = new AuthenticationScheme("ApiKey", null, typeof(ApiKeyAuthenticationHandler));
+            await handler.InitializeAsync(scheme, context);
+
+            return (handler, context);
+        }
+
+        [Test]
+        public async Task HandleAuthenticate_WhenHeaderMissing_ReturnsNoResult()
+        {
+            var (handler, _) = await CreateHandlerAsync();
+
+            var result = await handler.AuthenticateAsync();
+
+            Assert.That(result.None, Is.True);
+        }
+
+        [Test]
+        public async Task HandleAuthenticate_WhenKeyNotFound_ReturnsFail()
+        {
+            var (handler, context) = await CreateHandlerAsync();
+            context.Request.Headers["X-API-Key"] = "unknown-key";
+            _apiKeyRepo.Setup(x => x.GetByHashAsync(It.IsAny<byte[]>())).ReturnsAsync((ApiKey)null);
+
+            var result = await handler.AuthenticateAsync();
+
+            Assert.That(result.Succeeded, Is.False);
+            Assert.That(result.Failure!.Message, Is.EqualTo("Invalid API key"));
+        }
+
+        [Test]
+        public async Task HandleAuthenticate_WhenKeyValid_ReturnsSuccessWithUserIdClaim()
+        {
+            var (handler, context) = await CreateHandlerAsync();
+            var (apiKey, rawKey) = ApiKey.Create(42);
+            context.Request.Headers["X-API-Key"] = rawKey;
+            _apiKeyRepo.Setup(x => x.GetByHashAsync(It.IsAny<byte[]>())).ReturnsAsync(apiKey);
+
+            var result = await handler.AuthenticateAsync();
+
+            Assert.That(result.Succeeded, Is.True);
+            var userId = result.Principal!.FindFirstValue(ClaimTypes.NameIdentifier);
+            Assert.That(userId, Is.EqualTo("42"));
+        }
+    }
+}

--- a/CryptocurrencyExchange.Tests/ServicesTests/ApiKeyServiceTests.cs
+++ b/CryptocurrencyExchange.Tests/ServicesTests/ApiKeyServiceTests.cs
@@ -1,0 +1,79 @@
+using CryptocurrencyExchange.Application.ApiKeys;
+using CryptocurrencyExchange.Core.Interfaces;
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using CryptocurrencyExchange.Exceptions;
+using Moq;
+using NUnit.Framework;
+
+namespace CryptocurrencyExchange.Tests.ServicesTests
+{
+    [TestFixture]
+    public class ApiKeyServiceTests
+    {
+        private Mock<IApiKeyRepository> _apiKeyRepo;
+        private Mock<IUnitOfWork> _uow;
+        private ApiKeyService _service;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _apiKeyRepo = new Mock<IApiKeyRepository>();
+            _uow = new Mock<IUnitOfWork>();
+            _service = new ApiKeyService(_apiKeyRepo.Object, _uow.Object);
+        }
+
+        [Test]
+        public async Task GenerateAsync_WhenNoExistingKey_AddsKeyCommitsAndReturnsRawKey()
+        {
+            _apiKeyRepo.Setup(x => x.GetByUserIdAsync(1)).ReturnsAsync((ApiKey)null);
+
+            var rawKey = await _service.GenerateAsync(1);
+
+            Assert.That(rawKey, Is.Not.Null.And.Not.Empty);
+            _apiKeyRepo.Verify(x => x.DeleteAsync(It.IsAny<ApiKey>()), Times.Never);
+            _apiKeyRepo.Verify(x => x.AddAsync(It.IsAny<ApiKey>()), Times.Once);
+            _uow.Verify(x => x.CommitAsync(), Times.Once);
+        }
+
+        [Test]
+        public async Task GenerateAsync_WhenExistingKey_DeletesOldThenAddsNew()
+        {
+            var (existing, _) = ApiKey.Create(1);
+            _apiKeyRepo.Setup(x => x.GetByUserIdAsync(1)).ReturnsAsync(existing);
+
+            var callOrder = new List<string>();
+            _apiKeyRepo.Setup(x => x.DeleteAsync(existing))
+                .Callback(() => callOrder.Add("delete"))
+                .Returns(Task.CompletedTask);
+            _apiKeyRepo.Setup(x => x.AddAsync(It.IsAny<ApiKey>()))
+                .Callback(() => callOrder.Add("add"))
+                .Returns(Task.CompletedTask);
+
+            await _service.GenerateAsync(1);
+
+            Assert.That(callOrder, Is.EqualTo(new[] { "delete", "add" }));
+        }
+
+        [Test]
+        public async Task GetAsync_WhenKeyExists_ReturnsDtoWithPrefixAndCreatedAt()
+        {
+            var (apiKey, _) = ApiKey.Create(1);
+            _apiKeyRepo.Setup(x => x.GetByUserIdAsync(1)).ReturnsAsync(apiKey);
+
+            var dto = await _service.GetAsync(1);
+
+            Assert.That(dto.Prefix, Is.EqualTo(apiKey.KeyPrefix));
+            Assert.That(dto.CreatedAt, Is.EqualTo(apiKey.CreatedAt));
+        }
+
+        [Test]
+        public void GetAsync_WhenNoKey_ThrowsApiKeyNotFoundException()
+        {
+            _apiKeyRepo.Setup(x => x.GetByUserIdAsync(1)).ReturnsAsync((ApiKey)null);
+
+            Assert.ThrowsAsync<ApiKeyNotFoundException>(async () =>
+                await _service.GetAsync(1));
+        }
+    }
+}

--- a/CryptocurrencyExchange/Application/ApiKeys/ApiKeyDto.cs
+++ b/CryptocurrencyExchange/Application/ApiKeys/ApiKeyDto.cs
@@ -1,0 +1,4 @@
+namespace CryptocurrencyExchange.Application.ApiKeys
+{
+    public record ApiKeyDto(string Prefix, DateTime CreatedAt);
+}

--- a/CryptocurrencyExchange/Application/ApiKeys/ApiKeyService.cs
+++ b/CryptocurrencyExchange/Application/ApiKeys/ApiKeyService.cs
@@ -1,0 +1,41 @@
+using CryptocurrencyExchange.Core.Interfaces;
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Interfaces.Services;
+using CryptocurrencyExchange.Core.Models;
+using CryptocurrencyExchange.Exceptions;
+
+namespace CryptocurrencyExchange.Application.ApiKeys
+{
+    public class ApiKeyService : IApiKeyService
+    {
+        private readonly IApiKeyRepository _apiKeyRepository;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public ApiKeyService(IApiKeyRepository apiKeyRepository, IUnitOfWork unitOfWork)
+        {
+            _apiKeyRepository = apiKeyRepository;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<string> GenerateAsync(int userId)
+        {
+            var existing = await _apiKeyRepository.GetByUserIdAsync(userId);
+            if (existing != null)
+                await _apiKeyRepository.DeleteAsync(existing);
+
+            var (entity, rawKey) = ApiKey.Create(userId);
+            await _apiKeyRepository.AddAsync(entity);
+            await _unitOfWork.CommitAsync();
+            return rawKey;
+        }
+
+        public async Task<ApiKeyDto> GetAsync(int userId)
+        {
+            var apiKey = await _apiKeyRepository.GetByUserIdAsync(userId);
+            if (apiKey == null)
+                throw new ApiKeyNotFoundException();
+
+            return new ApiKeyDto(apiKey.KeyPrefix, apiKey.CreatedAt);
+        }
+    }
+}

--- a/CryptocurrencyExchange/Core/Entities/ApiKey.cs
+++ b/CryptocurrencyExchange/Core/Entities/ApiKey.cs
@@ -1,0 +1,36 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CryptocurrencyExchange.Core.Models
+{
+    public class ApiKey
+    {
+        public int Id { get; private set; }
+        public int UserId { get; private set; }
+        public byte[] KeyHash { get; private set; }
+        public string KeyPrefix { get; private set; }
+        public DateTime CreatedAt { get; private set; }
+
+        private ApiKey() { }
+
+        public ApiKey(int userId, byte[] keyHash, string keyPrefix, DateTime createdAt)
+        {
+            UserId = userId;
+            KeyHash = keyHash;
+            KeyPrefix = keyPrefix;
+            CreatedAt = createdAt;
+        }
+
+        public static (ApiKey apiKey, string rawKey) Create(int userId)
+        {
+            var randomBytes = RandomNumberGenerator.GetBytes(32);
+            var rawKey = Convert.ToBase64String(randomBytes)
+                .Replace('+', '-')
+                .Replace('/', '_')
+                .TrimEnd('=');
+            var keyPrefix = rawKey[..8];
+            var keyHash = SHA256.HashData(Encoding.UTF8.GetBytes(rawKey));
+            return (new ApiKey(userId, keyHash, keyPrefix, DateTime.UtcNow), rawKey);
+        }
+    }
+}

--- a/CryptocurrencyExchange/Core/Exceptions/ApiKeyNotFoundException.cs
+++ b/CryptocurrencyExchange/Core/Exceptions/ApiKeyNotFoundException.cs
@@ -1,0 +1,10 @@
+namespace CryptocurrencyExchange.Exceptions
+{
+    public class ApiKeyNotFoundException : Exception
+    {
+        public ApiKeyNotFoundException()
+            : base("API key not found.")
+        {
+        }
+    }
+}

--- a/CryptocurrencyExchange/Core/Interfaces/Repositories/IApiKeyRepository.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Repositories/IApiKeyRepository.cs
@@ -1,0 +1,12 @@
+using CryptocurrencyExchange.Core.Models;
+
+namespace CryptocurrencyExchange.Core.Interfaces.Repositories
+{
+    public interface IApiKeyRepository
+    {
+        Task<ApiKey?> GetByHashAsync(byte[] hash);
+        Task AddAsync(ApiKey apiKey);
+        Task<ApiKey?> GetByUserIdAsync(int userId);
+        Task DeleteAsync(ApiKey apiKey);
+    }
+}

--- a/CryptocurrencyExchange/Core/Interfaces/Services/IApiKeyService.cs
+++ b/CryptocurrencyExchange/Core/Interfaces/Services/IApiKeyService.cs
@@ -1,0 +1,10 @@
+using CryptocurrencyExchange.Application.ApiKeys;
+
+namespace CryptocurrencyExchange.Core.Interfaces.Services
+{
+    public interface IApiKeyService
+    {
+        Task<string> GenerateAsync(int userId);
+        Task<ApiKeyDto> GetAsync(int userId);
+    }
+}

--- a/CryptocurrencyExchange/Extensions/SecurityCollectionExtensions.cs
+++ b/CryptocurrencyExchange/Extensions/SecurityCollectionExtensions.cs
@@ -1,7 +1,12 @@
+using CryptocurrencyExchange.Application.ApiKeys;
 using CryptocurrencyExchange.Core.Interfaces;
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Interfaces.Services;
+using CryptocurrencyExchange.Infrastructure.Persistence.Repositories;
 using CryptocurrencyExchange.Infrastructure.Security;
 using CryptocurrencyExchange.Options;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using System.Threading.RateLimiting;
@@ -24,22 +29,30 @@ namespace CryptocurrencyExchange.Extensions
                 ?? throw new InvalidOperationException("Jwt configuration is missing");
 
             services
-                .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-                .AddJwtBearer(options =>
-                {
-                    options.TokenValidationParameters = new TokenValidationParameters
+                .AddAuthentication()
+                    .AddJwtBearer(options =>
                     {
-                        ValidateIssuerSigningKey = true,
-                        IssuerSigningKey = new SymmetricSecurityKey(
-                            Encoding.UTF8.GetBytes(jwtOptions.SecretKey)),
-                        ValidateIssuer = false,
-                        ValidateAudience = false,
-                        ValidateLifetime = true,
-                        ClockSkew = TimeSpan.Zero
-                    };
-                });
+                        options.TokenValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            IssuerSigningKey = new SymmetricSecurityKey(
+                                Encoding.UTF8.GetBytes(jwtOptions.SecretKey)),
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = true,
+                            ClockSkew = TimeSpan.Zero
+                        };
+                    })
+                    .AddScheme<ApiKeyAuthenticationOptions, ApiKeyAuthenticationHandler>("ApiKey", _ => { });
 
             services.AddScoped<ITokenService, JwtTokenService>();
+            services.AddScoped<IApiKeyRepository, EfApiKeyRepository>();
+            services.AddScoped<IApiKeyService, ApiKeyService>();
+
+            services.AddAuthorizationBuilder()
+                .SetDefaultPolicy(new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme, "ApiKey")
+                    .RequireAuthenticatedUser()
+                    .Build());
 
             return services;
         }

--- a/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/DataContext.cs
@@ -22,6 +22,7 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
         public DbSet<TransferVerificationOutbox> TransferVerificationOutbox { get; set; }
         public DbSet<TransferCompletedOutbox> TransferCompletedOutbox { get; set; }
         public DbSet<TransferIdempotentRequest> TransferIdempotentRequests { get; set; }
+        public DbSet<ApiKey> ApiKeys { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -34,6 +35,7 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
             ConfigureTransferVerificationOutbox(modelBuilder);
             ConfigureTransferCompletedOutbox(modelBuilder);
             ConfigureTransferIdempotentRequest(modelBuilder);
+            ConfigureApiKey(modelBuilder);
         }
 
         private static void ConfigureFuture(ModelBuilder modelBuilder)
@@ -141,6 +143,19 @@ namespace CryptocurrencyExchange.Infrastructure.Persistence
                 b.HasKey(r => r.Id);
                 b.Property(r => r.Key).IsRequired().HasMaxLength(128);
                 b.HasIndex(r => new { r.Key, r.UserId }).IsUnique();
+            });
+        }
+
+        private static void ConfigureApiKey(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ApiKey>(b =>
+            {
+                b.HasKey(k => k.Id);
+                b.Property(k => k.KeyHash).IsRequired();
+                b.Property(k => k.KeyPrefix).IsRequired().HasMaxLength(8);
+                b.HasIndex(k => k.UserId).IsUnique();
+                b.HasIndex(k => k.KeyHash);
+                b.HasOne<User>().WithMany().HasForeignKey(k => k.UserId).OnDelete(DeleteBehavior.Cascade);
             });
         }
 

--- a/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfApiKeyRepository.cs
+++ b/CryptocurrencyExchange/Infrastructure/Persistence/Repositories/EfApiKeyRepository.cs
@@ -1,0 +1,37 @@
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Core.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace CryptocurrencyExchange.Infrastructure.Persistence.Repositories
+{
+    public class EfApiKeyRepository : IApiKeyRepository
+    {
+        private readonly DataContext _dataContext;
+
+        public EfApiKeyRepository(DataContext dataContext)
+        {
+            _dataContext = dataContext;
+        }
+
+        public async Task<ApiKey?> GetByHashAsync(byte[] hash)
+        {
+            return await _dataContext.ApiKeys.FirstOrDefaultAsync(k => k.KeyHash == hash);
+        }
+
+        public async Task<ApiKey?> GetByUserIdAsync(int userId)
+        {
+            return await _dataContext.ApiKeys.FirstOrDefaultAsync(k => k.UserId == userId);
+        }
+
+        public async Task AddAsync(ApiKey apiKey)
+        {
+            await _dataContext.ApiKeys.AddAsync(apiKey);
+        }
+
+        public Task DeleteAsync(ApiKey apiKey)
+        {
+            _dataContext.ApiKeys.Remove(apiKey);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/CryptocurrencyExchange/Infrastructure/Security/ApiKeyAuthenticationHandler.cs
+++ b/CryptocurrencyExchange/Infrastructure/Security/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,46 @@
+using CryptocurrencyExchange.Core.Interfaces.Repositories;
+using CryptocurrencyExchange.Options;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+
+namespace CryptocurrencyExchange.Infrastructure.Security
+{
+    public class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthenticationOptions>
+    {
+        private readonly IApiKeyRepository _apiKeyRepository;
+
+        public ApiKeyAuthenticationHandler(
+            IOptionsMonitor<ApiKeyAuthenticationOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder,
+            ISystemClock clock,
+            IApiKeyRepository apiKeyRepository)
+            : base(options, logger, encoder, clock)
+        {
+            _apiKeyRepository = apiKeyRepository;
+        }
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue("X-API-Key", out var keyValues) || string.IsNullOrEmpty(keyValues))
+                return AuthenticateResult.NoResult();
+
+            var rawKey = keyValues.ToString();
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(rawKey));
+            var apiKey = await _apiKeyRepository.GetByHashAsync(hash);
+
+            if (apiKey == null)
+                return AuthenticateResult.Fail("Invalid API key");
+
+            var claims = new[] { new Claim(ClaimTypes.NameIdentifier, apiKey.UserId.ToString()) };
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            return AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name));
+        }
+    }
+}

--- a/CryptocurrencyExchange/Migrations/20260510133822_AddApiKey.Designer.cs
+++ b/CryptocurrencyExchange/Migrations/20260510133822_AddApiKey.Designer.cs
@@ -4,6 +4,7 @@ using CryptocurrencyExchange.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CryptocurrencyExchange.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20260510133822_AddApiKey")]
+    partial class AddApiKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CryptocurrencyExchange/Migrations/20260510133822_AddApiKey.cs
+++ b/CryptocurrencyExchange/Migrations/20260510133822_AddApiKey.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CryptocurrencyExchange.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddApiKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ApiKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<int>(type: "int", nullable: false),
+                    KeyHash = table.Column<byte[]>(type: "varbinary(900)", nullable: false),
+                    KeyPrefix = table.Column<string>(type: "nvarchar(8)", maxLength: 8, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiKeys", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ApiKeys_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiKeys_KeyHash",
+                table: "ApiKeys",
+                column: "KeyHash");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiKeys_UserId",
+                table: "ApiKeys",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ApiKeys");
+        }
+    }
+}

--- a/CryptocurrencyExchange/Options/ApiKeyAuthenticationOptions.cs
+++ b/CryptocurrencyExchange/Options/ApiKeyAuthenticationOptions.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Authentication;
+
+namespace CryptocurrencyExchange.Options
+{
+    public class ApiKeyAuthenticationOptions : AuthenticationSchemeOptions
+    {
+    }
+}

--- a/CryptocurrencyExchange/Presentation/Controllers/ApiKeyController.cs
+++ b/CryptocurrencyExchange/Presentation/Controllers/ApiKeyController.cs
@@ -1,0 +1,35 @@
+using CryptocurrencyExchange.Application.ApiKeys;
+using CryptocurrencyExchange.Core.Interfaces.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CryptocurrencyExchange.Presentation.Controllers
+{
+    [Authorize]
+    [Route("api/apikeys")]
+    public class ApiKeyController : ApiControllerBase
+    {
+        private readonly IApiKeyService _apiKeyService;
+
+        public ApiKeyController(IApiKeyService apiKeyService)
+        {
+            _apiKeyService = apiKeyService;
+        }
+
+        [HttpPost]
+        [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+        public async Task<ActionResult<string>> Generate()
+        {
+            var rawKey = await _apiKeyService.GenerateAsync(UserId);
+            return Ok(rawKey);
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<ApiKeyDto>> Get()
+        {
+            var dto = await _apiKeyService.GetAsync(UserId);
+            return Ok(dto);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds API key as a second authentication scheme alongside JWT Bearer
- Users can generate/regenerate a single key via `POST /api/apikeys` (JWT-only) and view it via `GET /api/apikeys`
- Incoming requests with `X-API-Key` header are validated against a SHA-256 hash stored in the DB; on success the same `ClaimTypes.NameIdentifier` claim is set, so all existing controllers work unchanged
- Both schemes are registered with no default; the default authorization policy accepts either, keeping `[Authorize]` on existing controllers untouched

## Test plan
- [ ] `POST /api/apikeys` with JWT → returns raw key
- [ ] `POST /api/apikeys` with API key → 401
- [ ] Authenticated request using `X-API-Key` header → succeeds, `UserId` resolves correctly
- [ ] `POST /api/apikeys` again → regenerates key, old key stops working
- [ ] `GET /api/apikeys` with no key generated → 404
- [ ] Run unit tests: `dotnet test`
- [ ] Apply migration: `dotnet ef database update`